### PR TITLE
Schema for permissions

### DIFF
--- a/schemas/access/bot-1.yml
+++ b/schemas/access/bot-1.yml
@@ -5,6 +5,8 @@ type: object
 properties:
   "$schema":
     type: string
+    enum:
+    - /access/bot-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
   name:

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -64,3 +64,4 @@ required:
 - labels
 - name
 - description
+- service

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -13,15 +13,54 @@ properties:
     type: string
   service:
     type: string
-    enum:
-    - aws-analytics
-    - github-org
-    - github-org-team
-    - openshift-rolebinding
-    - quay-org
+oneOf:
+- properties:
+    service:
+      enum:
+      - aws-analytics
+- properties:
+    service:
+      enum:
+      - github-org
+    org:
+      type: string
+  required:
+  - org
+- properties:
+    service:
+      enum:
+      - github-org-team
+    org:
+      type: string
+    team:
+      type: string
+  required:
+  - org
+  - team
+- properties:
+    service:
+      enum:
+      - openshift-rolebinding
+    cluster:
+      type: string
+    namespace:
+      type: string
+    role:
+      type: string
+  required:
+  - cluster
+  - namespace
+  - role
+- properties:
+    service:
+      enum:
+      - quay-org
+    org:
+      type: string
+  required:
+  - org
 required:
 - $schema
 - labels
 - name
 - description
-- service

--- a/schemas/access/permission-1.yml
+++ b/schemas/access/permission-1.yml
@@ -5,6 +5,8 @@ type: object
 properties:
   "$schema":
     type: string
+    enum:
+    - /access/permission-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
   name:

--- a/schemas/access/role-1.yml
+++ b/schemas/access/role-1.yml
@@ -5,6 +5,8 @@ type: object
 properties:
   "$schema":
     type: string
+    enum:
+    - /access/role-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
   name:

--- a/schemas/access/user-1.yml
+++ b/schemas/access/user-1.yml
@@ -5,6 +5,8 @@ type: object
 properties:
   "$schema":
     type: string
+    enum:
+    - /access/user-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
   name:

--- a/schemas/app-sre/app-1.yml
+++ b/schemas/app-sre/app-1.yml
@@ -7,6 +7,8 @@ additionalProperties: false
 properties:
   "$schema":
     type: string
+    enum:
+    - /app-sre/app-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
 

--- a/schemas/metaschema-1.json
+++ b/schemas/metaschema-1.json
@@ -5,7 +5,7 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "metaschema-1.json"
+      "enum": [ "/metaschema-1.json" ]
     },
     "version": {
       "$ref": "/common-1.json#/definitions/version"
@@ -22,7 +22,7 @@
           "properties": {
             "$ref": {
               "type": "string",
-              "const": "common-1.json#/definitions/labels"
+              "enum": [ "/common-1.json#/definitions/labels" ]
             }
           },
           "required": [
@@ -34,7 +34,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "const": "uri"
+              "enum": [ "string" ]
             }
           }
         }

--- a/schemas/openshift/cluster-1.yml
+++ b/schemas/openshift/cluster-1.yml
@@ -7,6 +7,8 @@ additionalProperties: false
 properties:
   "$schema":
     type: string
+    enum:
+    - /openshift/cluster-1.yml
   labels:
     "$ref": "/common-1.json#/definitions/labels"
   name:


### PR DESCRIPTION
This MR includes two changes:

- It turns out that draft04 does not support the keyword `const` so it wasn't doing anything. It has been replaced with a single element `enum` list.
- Certain types of permissions require specific associated attributes. These have been modelled into permission-1.yml schema.