### PR TITLE
bug: fix reload

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -119,8 +119,7 @@ const bundleFromS3 = async(accessKeyId: string, secretAccessKey: string, region:
 export const bundleFromDisk = async(path: string) => {
   const loadPath = typeof (path) === 'undefined' ? process.env.DATAFILES_FILE : path;
   const readFile = util.promisify(fs.readFile);
-  const contents = String(await readFile(path));
-
+  const contents = String(await readFile(loadPath));
   return parseBundle(contents);
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,8 +34,8 @@ export const appFromBundle = async(bundle: Promise<db.Bundle>) => {
 
   server.applyMiddleware({ app });
 
-  app.get('/reload', (req: express.Request, res: express.Response) => {
-    req.app.set('bundle', db.bundleFromEnvironment());
+  app.get('/reload', async (req: express.Request, res: express.Response) => {
+    req.app.set('bundle', await db.bundleFromEnvironment());
     res.send();
   });
 


### PR DESCRIPTION
Before this fix the server was unusable after doing `/reload`,
displaying this error:

```
TypeError: Cannot read property 'size' of undefined
    at app.use (webpack:///./src/server.ts?:22:86)
    at Layer.handle [as handle_request] (webpack:///./node_modules/express/lib/router/layer.js?:95:5)
    at trim_prefix (webpack:///./node_modules/express/lib/router/index.js?:317:13)
    at eval (webpack:///./node_modules/express/lib/router/index.js?:284:7)
    at Function.process_params (webpack:///./node_modules/express/lib/router/index.js?:335:12)
    at next (webpack:///./node_modules/express/lib/router/index.js?:275:10)
    at expressInit (webpack:///./node_modules/express/lib/middleware/init.js?:40:5)
    at Layer.handle [as handle_request] (webpack:///./node_modules/express/lib/router/layer.js?:95:5)
    at trim_prefix (webpack:///./node_modules/express/lib/router/index.js?:317:13)
    at eval (webpack:///./node_modules/express/lib/router/index.js?:284:7)
```

The key problem is that the `/reload` route calls `db.bundleFromEnvironment()`
which is a promise, but it doesn't wait for it to resolve.

I also had to change the bundle reference in all the resolver functions in
`schema.ts` because otherwise after reload if continued serving the old data.
This is because it kept in its scope a reference to the original bundle pointed
at during load time.