### PR TITLE
Add serviceDocs to app schema

### DIFF
--- a/assets/schema.yml
+++ b/assets/schema.yml
@@ -272,6 +272,7 @@
   - { name: path, type: string, isRequired: true }
   - { name: labels, type: json }
   - { name: title, type: string, isRequired: true }
+  - { name: serviceDocs, type: string, isList: true }
   - { name: serviceOwner, type: AppServiceOwner, isRequired: true }
   - { name: dependencies, type: AppDependencies, isList: true }
   - { name: quayRepos, type: AppQuayRepos, isList: true }

--- a/assets/schemas/app-sre/app-1.yml
+++ b/assets/schemas/app-sre/app-1.yml
@@ -15,6 +15,13 @@ properties:
   title:
     type: string
 
+  serviceDocs:
+    description: List of service docs
+    type: array
+    items:
+      description: Service document link
+      type: string
+
   serviceOwner:
     description: Team or individual who is/are responsible for the running instance of the software.
     type: object


### PR DESCRIPTION
This adds a serviceDocs property to the app schema. The serviceDocs property is a list of string that is used to reference service-related documentation.