### PR TITLE
Add basic metrics for qontract-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jsonpointer": "^4.0.1",
     "node-forge": "^0.7.6",
     "path": "^0.12.7",
+    "prom-client": "^11.5.3",
     "utf-8-validate": "^5.0.2"
   },
   "devDependencies": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,26 @@ import * as express from 'express';
 import * as db from './db';
 import { generateAppSchema, defaultResolver  } from './schema';
 
+import prometheusClient = require('prom-client');
+
+// enable prom-client to expose default application metrics
+const collectDefaultMetrics = prometheusClient.collectDefaultMetrics;
+
+// Probe every 5th second.
+collectDefaultMetrics({ prefix: 'qontract_server_' });
+
+// Create metric stores
+const reloadCounter = new prometheusClient.Counter({
+  name: 'qontract_server_reloads_total',
+  help: 'Number of reloads for qontract server'
+});
+
+const datafilesGuage = new prometheusClient.Gauge({
+  name: 'qontract_server_datafiles',
+  help: 'Number of datafiles for a specific schema',
+  labelNames: ['schema']
+});
+
 const readFile = util.promisify(fs.readFile);
 
 export const appFromBundle = async(bundle: Promise<db.Bundle>) => {
@@ -46,6 +66,19 @@ export const appFromBundle = async(bundle: Promise<db.Bundle>) => {
       req.app.set('bundle', bundle);
       req.app.get('server').schema = generateAppSchema(req.app as express.Express);
 
+      // Count number of files for each schema type
+      let schema_count = bundle.datafiles.reduce((acc, d) => {
+        if (!(d.$schema in acc)) {
+            acc[d.$schema] = 0;
+        }
+        acc[d.$schema]++;
+        return acc;
+      }, {});
+      // Set the Guage based on counted metrics
+      Object.keys(schema_count).map(function(schemaName,_){
+        datafilesGuage.set({schema: schemaName}, schema_count[schemaName]);
+      })
+      reloadCounter.inc(1, Date.now())
       console.log('reloaded');
       res.send();
     } catch (e) {
@@ -56,6 +89,10 @@ export const appFromBundle = async(bundle: Promise<db.Bundle>) => {
   app.get('/sha256', (req: express.Request, res: express.Response) => {
     const hash = req.app.get('bundle').fileHash;
     res.send(hash);
+  });
+
+  app.get('/metrics', (req: express.Request, res: express.Response) => {
+    res.send(prometheusClient.register.metrics());
   });
 
   app.get('/healthz', (req: express.Request, res: express.Response) => { res.send(); });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,11 +2576,6 @@ lodash@^4.17.10:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.4:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -3250,13 +3245,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promjs@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/promjs/-/promjs-0.4.0.tgz#a9def6faecfbb593d3f8b2af8858452bd79660f3"
-  integrity sha512-HqpT9m9U+QCEqAiJ504FfJKEP0sS/gpdFEjeJjR33POIDINGtp1HDoABP3+9K239JHw9Sk8F4FmkEIRuisSGhQ==
-  dependencies:
-    lodash "^4.17.4"
 
 protobufjs@^6.8.6:
   version "6.8.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
   integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 bluebird@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
@@ -2571,6 +2576,11 @@ lodash@^4.17.10:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
+lodash@^4.17.4:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -3229,10 +3239,24 @@ process@^0.11.1, process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+prom-client@^11.5.3:
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.5.3.tgz#5fedfce1083bac6c2b223738e966d0e1643756f8"
+  integrity sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promjs@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/promjs/-/promjs-0.4.0.tgz#a9def6faecfbb593d3f8b2af8858452bd79660f3"
+  integrity sha512-HqpT9m9U+QCEqAiJ504FfJKEP0sS/gpdFEjeJjR33POIDINGtp1HDoABP3+9K239JHw9Sk8F4FmkEIRuisSGhQ==
+  dependencies:
+    lodash "^4.17.4"
 
 protobufjs@^6.8.6:
   version "6.8.8"
@@ -3911,6 +3935,13 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 terser-webpack-plugin@^1.1.0:
   version "1.2.1"


### PR DESCRIPTION
Add a bunch of metrics for qontract server, including: 

- NodeJS runtime metrics
- Count of datafiles currently known to qontract-server per schema type

Full list of metrics: 
```
qontract_server_nodejs_external_memory_bytes{}
qontract_server_nodejs_heap_size_used_bytes{}
qontract_server_process_resident_memory_bytes{}
qontract_server_process_cpu_system_seconds_total{}
qontract_server_process_heap_bytes{}
qontract_server_process_start_time_seconds{}
qontract_server_nodejs_heap_space_size_available_bytes{}
qontract_server_nodejs_heap_space_size_total_bytes{}
qontract_server_nodejs_heap_space_size_used_bytes{}
qontract_server_process_open_fds{}
qontract_server_process_virtual_memory_bytes{}
scrape_samples_post_metric_relabeling{}
qontract_server_nodejs_active_handles_total{}
qontract_server_nodejs_active_requests{}
qontract_server_process_max_fds{}
qontract_server_nodejs_heap_size_total_bytes{}
qontract_server_nodejs_version_info{}
qontract_server_process_cpu_seconds_total{}
qontract_server_process_cpu_user_seconds_total{}
qontract_server_reloads_total{}
qontract_server_nodejs_active_handles{}
qontract_server_nodejs_active_requests_total{}
qontract_server_nodejs_eventloop_lag_seconds{}
```