### PR TITLE
Makefile: run container interactively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ run:
 	LOAD_METHOD=fs DATAFILES_FILE=$(BUNDLE_DIR)/$(BUNDLE_FILENAME) yarn run server
 
 docker-run:
-	@docker run --rm \
+	@docker run -it --rm \
 		-v $(BUNDLE_DIR):/bundle:z \
 		-p 4000:4000 \
 		-e LOAD_METHOD=fs \


### PR DESCRIPTION
This updates the Makefile to run the docker container interactively and with pseudo-tty so it can catch a Ctrl-C / SIGINT from the host which is especially useful when running locally