### PR TITLE
Adds an extension that returns all traversed schemas

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -71,6 +71,14 @@ export const defaultResolver = (app: express.Express) => (root: any,
                                                           args: any,
                                                           context: any,
                                                           info: any) => {
+  if ('schemas' in context) {
+    if (!context.schemas.includes(root.$schema)) {
+      context['schemas'].push(root.$schema);
+    }
+  } else {
+    context['schemas'] = [root.$schema];
+  }
+
   if (info.fieldName === 'schema') return root.$schema;
 
   const val = root[info.fieldName];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -71,12 +71,15 @@ export const defaultResolver = (app: express.Express) => (root: any,
                                                           args: any,
                                                           context: any,
                                                           info: any) => {
-  if ('schemas' in context) {
-    if (!context.schemas.includes(root.$schema)) {
-      context['schemas'].push(root.$schema);
+  // add root.$schema to the schemas extensions
+  if (typeof(root.$schema) !== 'undefined') {
+    if ('schemas' in context) {
+      if (!context.schemas.includes(root.$schema)) {
+        context['schemas'].push(root.$schema);
+      }
+    } else {
+      context['schemas'] = [root.$schema];
     }
-  } else {
-    context['schemas'] = [root.$schema];
   }
 
   if (info.fieldName === 'schema') return root.$schema;

--- a/src/server.ts
+++ b/src/server.ts
@@ -83,6 +83,17 @@ export const appFromBundle = async (bundle: Promise<db.Bundle>) => {
       playground: true,
       introspection: true,
       fieldResolver: defaultResolver(app),
+      plugins: [
+        {
+          requestDidStart(requestContext) {
+            return {
+              willSendResponse(requestContext) {
+                requestContext.response.extensions = { schemas: requestContext.context.schemas };
+              },
+            };
+          },
+        },
+      ],
     });
   } catch (e) {
     console.error(`error creating server: ${e}`);

--- a/test/schemas/cluster.test.ts
+++ b/test/schemas/cluster.test.ts
@@ -24,6 +24,7 @@ describe('clusters', async() => {
       { query: '{ clusters: clusters_v1 { name } }' },
     );
     resp.should.have.status(200);
+    resp.body.extensions.schemas.should.eql(['/openshift/cluster-1.yml']);
     return resp.body.data.clusters[0].name.should.equal('example cluster');
   });
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -52,7 +52,6 @@ describe('server', async() => {
 
     response.body.extensions.schemas.should.eql(['/access/role-1.yml', '/access/permission-1.yml']);
     return response.body.data.roles[0].permissions[0].service.should.equal('github-org-team');
-
   });
 
   it('resolves object refs', async() => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -20,7 +20,7 @@ const expect = chai.expect;
 const responseIsNotAnError = (res: any) => {
   res.should.have.status(200);
   res.body.should.not.have.any.keys('errors');
-  res.body.should.have.all.keys('data');
+  res.body.should.have.all.keys('data', 'extensions');
 };
 
 describe('server', async() => {
@@ -49,7 +49,10 @@ describe('server', async() => {
 
     const response = await chai.request(srv).get('/graphql').query({ query });
     responseIsNotAnError(response);
+
+    response.body.extensions.schemas.should.eql(['/access/role-1.yml', '/access/permission-1.yml']);
     return response.body.data.roles[0].permissions[0].service.should.equal('github-org-team');
+
   });
 
   it('resolves object refs', async() => {
@@ -97,6 +100,8 @@ describe('server', async() => {
 
     const response1 = await chai.request(srv).get('/graphql').query({ query });
     responseIsNotAnError(response1);
+    response1.body.extensions.schemas.should.eql(['/access/role-1.yml',
+      '/access/permission-1.yml']);
     response1.body.data.roles[0].permissions[0].org.should.equal('org-A');
 
     // check that it continues to work after a reload
@@ -105,6 +110,8 @@ describe('server', async() => {
     const response2 = await chai.request(srv).get('/graphql').query({ query });
     responseIsNotAnError(response2);
 
+    response1.body.extensions.schemas.should.eql(['/access/role-1.yml',
+      '/access/permission-1.yml']);
     const perm = response2.body.data.roles[0].permissions[0];
     expect(perm.org).to.equal('org-A');
   });


### PR DESCRIPTION
The current response payload that this server is implementing only contains `data` and `errors`:

```json
{
  "data": ...,
  "errors": ...,
}
```

We now require a complete list of schemas that each query has traversed, to
identify schema dependencies per query.

The GraphQL spec [1] supports creating extensions (plugins) to add additional custom
data to the response payload.

This PR includes a plugin that adds an additional field `extensions` to the response payload:

```json
{
  "data": ...,
  "errors": ...,
  "extensions": {
    "schemas": ["/schema1.yaml",...]
  }
}
```

[1]: https://spec.graphql.org/June2018/#sec-Response-Format
