### PR TITLE
APPSRE-1045: query objects using arbitrary arguments

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -22,6 +22,7 @@ const isRef = (obj: Object): boolean => {
   return obj.constructor === Object && Object.keys(obj).length === 1 && '$ref' in obj;
 };
 
+// object types helpers
 const addObjectType = (app: express.Express, bundleSha: string, name: string, obj: any) => {
   if (typeof (app.get('objectTypes')[bundleSha]) === 'undefined') {
     app.get('objectTypes')[bundleSha] = {};
@@ -33,6 +34,7 @@ const getObjectType = (app: express.Express, bundleSha: string, name: string) =>
   return app.get('objectTypes')[bundleSha][name];
 };
 
+// interface types helpers
 const addInterfaceType = (app: express.Express, bundleSha: string, name: string, obj: any) => {
   if (typeof (app.get('objectInterfaces')[bundleSha]) === 'undefined') {
     app.get('objectInterfaces')[bundleSha] = {};
@@ -43,8 +45,10 @@ const addInterfaceType = (app: express.Express, bundleSha: string, name: string,
 const getInterfaceType = (app: express.Express, bundleSha: string, name: string) =>
   app.get('objectInterfaces')[bundleSha][name];
 
+// helpers
 const isNonEmptyArray = (obj: any) => obj.constructor === Array && obj.length > 0;
 
+// synthetic field resolver
 const resolveSyntheticField = (app: express.Express,
                                bundleSha: string,
                                path: string,
@@ -71,6 +75,7 @@ const resolveSyntheticField = (app: express.Express,
     return false;
   }).values());
 
+// default resolver
 export const defaultResolver = (app: express.Express, bundleSha: string) =>
   (root: any, args: any, context: any, info: any) => {
     // add root.$schema to the schemas extensions

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -185,8 +185,15 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
         fieldDef['resolve'] = (root: any, args: any) => {
           return Array.from(app.get('bundles')[bundleSha].datafiles.filter(
             (df: db.Datafile) => {
-              const sameSchema: boolean = df.$schema === fieldInfo.datafileSchema;
-              return args.path ? df.path === args.path && sameSchema : sameSchema;
+              if (df.$schema !== fieldInfo.datafileSchema) {
+                return false;
+              }
+              for (const key of Object.keys(args)) {
+                if (!(key in df) || args[key] !== df[key]) {
+                  return false;
+                }
+              }
+              return true;
             }).values());
         };
       } else if (fieldInfo.synthetic) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,6 +79,9 @@ const removeExpiredBundles = (app: express.Express) => {
 
       // remove from bundleCache
       delete app.get('bundleCache')[sha];
+
+      // remove from searchableFields
+      delete app.get('searchableFields')[sha];
     }
   }
 };
@@ -197,6 +200,7 @@ export const appFromBundle = async (bundlePromise: Promise<db.Bundle>) => {
 
     fullCacheInfo['bundles'] = Object.keys(req.app.get('bundles'));
     fullCacheInfo['routerStack'] = app._router.stack.length;
+    fullCacheInfo['searchableFields'] = Object.keys(req.app.get('searchableFields'));
 
     res.send(JSON.stringify(fullCacheInfo));
   });

--- a/test/server.data.json
+++ b/test/server.data.json
@@ -42,6 +42,12 @@
         }
       ]
     },
+    "/role-B.yml": {
+      "$schema": "/access/role-1.yml",
+      "labels": {},
+      "name": "role-B",
+      "permissions": []
+    },
     "/quay-org-A.yml": {
       "$schema": "/dependencies/quay-org-1.yml",
       "labels": {},
@@ -1107,6 +1113,7 @@
         },
         {
           "isRequired": true,
+          "isSearchable": true,
           "type": "string",
           "name": "name"
         },

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -92,6 +92,54 @@ describe('server', async () => {
     return response.body.data.resources[0].content.should.equal('test resource');
   });
 
+  it('can search by path', async () => {
+    const query = `{
+      roles_v1(path: "/role-A.yml") {
+        path
+        name
+      }
+    }`;
+
+    const response = await chai.request(srv)
+                            .post('/graphql')
+                            .set('content-type', 'application/json')
+                            .send({ query });
+    responseIsNotAnError(response);
+    return response.body.data.roles_v1[0].name.should.equal('role-A');
+  });
+
+  it('can search by name (isSearchable)', async () => {
+    const query = `{
+      roles_v1(name: "role-B") {
+        path
+        name
+      }
+    }`;
+
+    const response = await chai.request(srv)
+                            .post('/graphql')
+                            .set('content-type', 'application/json')
+                            .send({ query });
+    responseIsNotAnError(response);
+    return response.body.data.roles_v1[0].path.should.equal('/role-B.yml');
+  });
+
+  it('cannot search by name (NOT isSearchable)', async () => {
+    const query = `{
+      quay_orgs_v1(name:"quay-org-A") {
+        path
+        name
+      }
+    }`;
+
+    const response = await chai.request(srv)
+                            .post('/graphql')
+                            .set('content-type', 'application/json')
+                            .send({ query });
+
+    return response.should.not.have.status(200);
+  });
+
   it('can retrieve a field from an interface', async () => {
     const query = `{
       roles: roles_v1(path: "/role-A.yml") {


### PR DESCRIPTION
This PR introduces a new feature to allow querying for specific fields in the schema. This is useful because otherwise the filtering needs to happen in the client side wasting bandwidth.

The GraphQL schema defined in the bundle now allows users to mark fields with the `isSearchable: true` attribute. This will make the specific attribute queryable.

For example, with this schema:

```yaml
datafile: /access/role-1.yml
name: Role_v1
fields:
  - name: name
    type: string
    isRequired: true
    isSearchable: true
  - ...
```

It will be possible to run the following query: `{ role_v1(name: "<name>") { path, name}}`.

Note that querying for the `path` attribute is implicitely supported for all datafiles (as it's a mandatory attribute).