### PR TITLE
APPSRE-3783: Add pr_check.sh that contains the removed TravisCI yarn commands.

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+yarn run lint
+
+yarn test


### PR DESCRIPTION
### Why
Now that Travis CI was removed, we want to use the default pr_check.sh as part of the build
### What
Adding pr_check.sh 
* No need to do `yarn install` because the image has yarn built in according to the Dockerfile.
### Validation
Ran `qontract-reconcile --config config.debug.toml --dry-run --log-level DEBUG jenkins-job-builder` locally and it passed. 