### PR TITLE
Use container to install and run yarn instead.

### DIFF
--- a/Dockerfiletest
+++ b/Dockerfiletest
@@ -1,0 +1,16 @@
+FROM quay.io/centos/centos:7
+
+# Set PATH, because "scl enable" does not have any effects to "docker build"
+ENV PATH /opt/rh/rh-nodejs10/root/usr/bin:$PATH
+
+# enable scl with nodejs8
+RUN yum install centos-release-scl-rh -y && \
+    yum install rh-nodejs10 rh-nodejs10-npm -y && \
+    yum clean all && \
+    npm install -g yarn
+
+ENV APP_ROOT /opt/qontract-server
+ADD . ${APP_ROOT}
+WORKDIR ${APP_ROOT}
+
+RUN yarn install && yarn run lint && yarn test 

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-yarn run lint
-
-yarn test
+docker build --pull -t quay.io/app-sre/qontract-server:test -f Dockerfiletest .


### PR DESCRIPTION
Instead of directly in Jenkins executor, use container to install and run yarn for pr_check.