### PR TITLE
Use non-deprecated topology keys

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -57,7 +57,7 @@ objects:
                       operator: In
                       values:
                       - app-interface
-                  topologyKey: failure-domain.beta.kubernetes.io/zone
+                  topologyKey: topology.kubernetes.io/zone
                 weight: 100
         containers:
         - image: ${IMAGE_GATE}:${IMAGE_GATE_TAG}


### PR DESCRIPTION
failure-domain.beta.kubernetes.io/zone is deprecated from 1.17

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>