### PR TITLE
[WIP] Properly print newlines for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ bundle:
 	@$(CONTAINER_ENGINE) run --rm \
 		-v $(BUNDLE_DIR):/bundle:z \
 		$(VALIDATOR_IMAGE_NAME):$(VALIDATOR_IMAGE_TAG) \
-		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME)
+		qontract-validator --only-errors /bundle/$(BUNDLE_FILENAME) \
+		| sed 's/\\n/\n/g' # Without this, the error messages show newlines as \n -> hard to read
 
 run:
 	LOAD_METHOD=fs DATAFILES_FILE=$(BUNDLE_DIR)/$(BUNDLE_FILENAME) yarn run server


### PR DESCRIPTION
Currently, newlines appear like

```
[                                                                                                                                                                                                          
    {                                                                                                                                                                                                      
        "filename": "/services/some.yml",                                                                                                                         
        "kind": "FILE",                                                                                                                                                                                    
        "result": {                                                                                                                                                                                        
            "summary": "ERROR: /some/yml",                                                                                                               
            "status": "ERROR",                                                                                                                                                                             
            "reason": "VALIDATION_ERROR",                                                                                                                                                                  
            "error": "Additional properties are not allowed ('publish_log_types' was unexpected)\n\nFailed validating 'additionalProperties' in schema['properties']['terraformResources']['items']:\n    {
'$schema': '/metaschema-1.json',\n     'additionalProperties': False,\n     'oneOf': [{'$ref': '/aws/some2-1.yml'},\n               {'additionalProperties': False,\n                'properties': {'account':
 {'$ref': '/aws/some.yml#/properties/account'},\n                               'annotations': {'$ref': '/some.json#/definitions/annotations'},\n                               'aws_infra
structure_access': {'additionalProperties': False,\n
```

Via `sed` the same error message is easier to comprehend:

```
[                                                                                                                                                                                                          
    {                                                                                                                                                                                                      
         "filename": "/services/some.yml",  
        "kind": "FILE",
        "result": {
            "summary": "ERROR: /services/some.yml",
            "status": "ERROR",
            "reason": "VALIDATION_ERROR",
            "error": "Additional properties are not allowed ('publish_log_types' was unexpected)

Failed validating 'additionalProperties' in schema['properties']['terraformResources']['items']:
    {'$schema': '/metaschema-1.json',
     'additionalProperties': False,
     'oneOf': [{'$ref': '/aws/some2-1.yml'},
               {'additionalProperties': False,
```