### PR TITLE
allow loading multiple fs bundles on startup

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -131,6 +131,14 @@ export const bundleFromDisk = async(path: string) => {
   return parseBundle(contents);
 };
 
+export const getInitialBundles = () => {
+  if (process.env.INIT_DISK_BUNDLES) {
+    return process.env.INIT_DISK_BUNDLES.split(",").map((path: any) => bundleFromDisk(path))
+  } else {
+    return [bundleFromEnvironment()]
+  }
+}
+
 export const bundleFromEnvironment = async() => {
   switch (process.env.LOAD_METHOD) {
     case 'fs':

--- a/src/db.ts
+++ b/src/db.ts
@@ -133,11 +133,10 @@ export const bundleFromDisk = async(path: string) => {
 
 export const getInitialBundles = () => {
   if (process.env.INIT_DISK_BUNDLES) {
-    return process.env.INIT_DISK_BUNDLES.split(",").map((path: any) => bundleFromDisk(path))
-  } else {
-    return [bundleFromEnvironment()]
+    return process.env.INIT_DISK_BUNDLES.split(',').map((path: any) => bundleFromDisk(path));
   }
-}
+  return [bundleFromEnvironment()];
+};
 
 export const bundleFromEnvironment = async() => {
   switch (process.env.LOAD_METHOD) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -95,13 +95,14 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
   //   <bundleSha>: <bundle>
   const bundles: any = {};
 
-  let bundleSha: string;
+  let sha: string;
   for (const bp of bundlePromises) {
     const bundle = await bp;
-    bundleSha = bundle.fileHash;
-    bundles[bundleSha] = bundle;
-    logger.info('loading initial bundle %s', bundleSha);
+    sha = bundle.fileHash;
+    bundles[sha] = bundle;
+    logger.info('loading initial bundle %s', sha);
   }
+  const bundleSha = sha;
 
   app.set('bundles', bundles);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,16 +87,22 @@ const removeExpiredBundles = (app: express.Express) => {
 };
 
 // Create application
-export const appFromBundle = async (bundlePromise: Promise<db.Bundle>) => {
+export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
   const app: express.Express = express();
 
   // Create the initial `bundles` object. This object will have this shape:
   // bundles:
   //   <bundleSha>: <bundle>
-  const bundle = await bundlePromise;
-  const bundleSha = bundle.fileHash;
   const bundles: any = {};
-  bundles[bundleSha] = bundle;
+
+  let bundleSha: string;
+  for (const bp of bundlePromises) {
+    const bundle = await bp;
+    bundleSha = bundle.fileHash;
+    bundles[bundleSha] = bundle;
+    logger.info('loading initial bundle %s', bundleSha);
+  }
+
   app.set('bundles', bundles);
 
   // Create cache object
@@ -236,7 +242,7 @@ export const appFromBundle = async (bundlePromise: Promise<db.Bundle>) => {
 
 // If this is main, load an app from the environment and run the server.
 if (!module.parent) {
-  const app = appFromBundle(db.bundleFromEnvironment());
+  const app = appFromBundle(db.getInitialBundles());
 
   app.then((app) => {
     app.listen({ port: 4000 }, () => {

--- a/test/multishas/multishas.test.ts
+++ b/test/multishas/multishas.test.ts
@@ -34,7 +34,7 @@ describe('multishas', async () => {
     process.env.LOAD_METHOD = 'fs';
     process.env.DATAFILES_FILE = 'test/multishas/multishas1.data.json';
 
-    app = await server.appFromBundle(db.bundleFromEnvironment());
+    app = await server.appFromBundle([db.bundleFromEnvironment()]);
     srv = app.listen({ port: 4000 });
   });
 

--- a/test/schemas/schemas.test.ts
+++ b/test/schemas/schemas.test.ts
@@ -17,7 +17,7 @@ describe('clusters', async() => {
   before(async() => {
     process.env.LOAD_METHOD = 'fs';
     process.env.DATAFILES_FILE = 'test/schemas/schemas.data.json';
-    const app = await server.appFromBundle(db.bundleFromEnvironment());
+    const app = await server.appFromBundle(db.getInitialBundles());
     srv = app.listen({ port: 4000 });
   });
 
@@ -30,5 +30,25 @@ describe('clusters', async() => {
     resp.should.have.status(200);
     resp.body.extensions.schemas.should.eql(['/openshift/cluster-1.yml']);
     return resp.body.data.clusters[0].name.should.equal('example cluster');
+  });
+});
+
+describe('clusters', async() => {
+  let srv: http.Server;
+  before(async() => {
+    process.env.INIT_DISK_BUNDLES = 'test/schemas/schemas.data.json';
+    const app = await server.appFromBundle(db.getInitialBundles());
+    srv = app.listen({ port: 4000 });
+  });
+
+  it('check if init disk bundle loads the bundle', async() => {
+    const resp = await chai.request(srv)
+                        .get('/sha256');
+    resp.should.have.status(200);
+    return resp.text.should.eql('242acb1998e9d37c26186ba9be0262fb34e3ef388b503390d143164f7658c24e');
+  });
+
+  before(() => {
+    delete process.env.INIT_DISK_BUNDLES;
   });
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -26,7 +26,7 @@ describe('server', async () => {
   before(async () => {
     process.env.LOAD_METHOD = 'fs';
     process.env.DATAFILES_FILE = 'test/server.data.json';
-    const app = await server.appFromBundle(db.bundleFromEnvironment());
+    const app = await server.appFromBundle(db.getInitialBundles());
     srv = app.listen({ port: 4000 });
   });
   after(async () => await util.promisify(srv.close));


### PR DESCRIPTION
if the env variable `INIT_DISK_BUNDLES` is given, it is processed as CSV list of bundle paths to be loaded into the bundle cache.

this is a feature that will be used mostly during PR checks. having a qontract-server running with two bundles, enables us to compute rich diffs between bundles. this PR will be followed up by one that introduces a qontract-server endpoint `/diff/$sha/$sha` that will return the differences from one bundle to another (the change of an MR). we do something similar right now during app-interface pr checks already but based on `git diff`, which lacks context. e.g. if a resource is changed, what datafile does it belong to and what shard of what integration do we need to run during a PR check.

alternatively we could also start the q-s with one bundle, wait for it to be loaded, overwrite the bundle on disk and trigger a reload but that is more cumbersome as the proposed solution.

this is part of the 1st milestone of the fine grained permission initiative. jira tickets need yet to be created and i will link the appropriate one before i expect an LGTM

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>