### PR TITLE
resource reference resolver

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -243,7 +243,8 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
             }
             return null;
           };
-        } else if (fieldInfo.type === getObjectType(app, bundleSha, 'Resource_v1')) {
+        /* tslint:disable:triple-equals */
+        } else if (fieldInfo.type == getObjectType(app, bundleSha, 'Resource_v1')) {
           // a resource
           fieldDef['args'] = { path: { type: GraphQLString }, schema: { type: GraphQLString } };
           fieldDef['resolve'] = (root: any, args: any) => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -92,7 +92,7 @@ const resolveSyntheticField = (app: express.Express,
 export const defaultResolver = (app: express.Express, bundleSha: string) =>
   (root: any, args: any, context: any, info: any) => {
     // add root.$schema to the schemas extensions
-    if (typeof (root.$schema) !== 'undefined') {
+    if (typeof (root.$schema) !== 'undefined' && root.$schema) {
       if ('schemas' in context) {
         if (!context.schemas.includes(root.$schema)) {
           context['schemas'].push(root.$schema);
@@ -234,21 +234,32 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
           fieldInfo.synthetic.subAttr,
         );
       } else if (fieldInfo.isResource) {
-        // resource
-        fieldDef['args'] = { path: { type: GraphQLString }, schema: { type: GraphQLString } };
-        fieldDef['resolve'] = (root: any, args: any) => {
-          if (args.path) {
-            return [app.get('bundles')[bundleSha].resourcefiles.get(args.path)];
-          }
+        if (fieldInfo.type === 'string' && fieldInfo.resolveResource) {
+          // a resource reference
+          fieldDef['type'] = getObjectType(app, bundleSha, 'Resource_v1');
+          fieldDef['resolve'] = (root: any) => {
+            if (root[fieldInfo.name] !== undefined) {
+              return app.get('bundles')[bundleSha].resourcefiles.get(root[fieldInfo.name]);
+            }
+            return null;
+          };
+        } else if (fieldInfo.type == getObjectType(app, bundleSha, 'Resource_v1')) {
+          // a resource
+          fieldDef['args'] = { path: { type: GraphQLString }, schema: { type: GraphQLString } };
+          fieldDef['resolve'] = (root: any, args: any) => {
+            if (args.path) {
+              return [app.get('bundles')[bundleSha].resourcefiles.get(args.path)];
+            }
 
-          let results = Array.from(app.get('bundles')[bundleSha].resourcefiles.values());
+            let results = Array.from(app.get('bundles')[bundleSha].resourcefiles.values());
 
-          if (args.schema) {
-            results = results.filter((r: any) => r.$schema === args.schema);
-          }
+            if (args.schema) {
+              results = results.filter((r: any) => r.$schema === args.schema);
+            }
 
-          return results;
-        };
+            return results;
+          };
+        }
       }
 
       // return

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -243,7 +243,7 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
             }
             return null;
           };
-        } else if (fieldInfo.type == getObjectType(app, bundleSha, 'Resource_v1')) {
+        } else if (fieldInfo.type === getObjectType(app, bundleSha, 'Resource_v1')) {
           // a resource
           fieldDef['args'] = { path: { type: GraphQLString }, schema: { type: GraphQLString } };
           fieldDef['resolve'] = (root: any, args: any) => {

--- a/test/resourceref/data.json
+++ b/test/resourceref/data.json
@@ -1,0 +1,86 @@
+{
+    "data": {
+        "/test.yml": {
+            "$schema": "/test-type-1.yml",
+            "name": "name",
+            "unresolvable_resource_ref": "/resource1.yml",
+            "resolvable_resource_ref": "/resource1.yml"
+        }
+    },
+    "graphql": {
+        "$schema" : "/app-interface/graphql-schemas-1.yml",
+        "confs": [
+            {
+                "fields": [
+                {
+                    "isRequired": true,
+                    "type": "string",
+                    "name": "name"
+                },
+                {
+                    "isResource": true,
+                    "type": "string",
+                    "name": "unresolvable_resource_ref"
+                },
+                {
+                    "isResource": true,
+                    "resolveResource": true,
+                    "type": "string",
+                    "name": "resolvable_resource_ref"
+                    }
+                ],
+                "name": "TestType_v1"
+            },
+            {
+                "fields": [
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "path"
+                    },
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "content"
+                    },
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "sha256sum"
+                    },
+                    {
+                        "type": "string",
+                        "name": "schema"
+                    }
+                ],
+                "name": "Resource_v1"
+            },
+            {
+                "fields": [
+                {
+                    "type": "TestType_v1",
+                    "name": "test_type_v1",
+                    "isList": true,
+                    "datafileSchema": "/test-type-1.yml"
+                },
+                {
+                    "isRequired": true,
+                    "isResource": true,
+                    "type": "Resource_v1",
+                    "name": "resources_v1",
+                    "isList": true
+                }
+                ],
+                "name": "Query"
+            }
+        ]
+    },
+    "resources": {
+        "/resource1.yml": {
+            "content": "test resource",
+            "path": "/resource1.yml",
+            "sha256sum": "ff",
+            "$schema": null
+        }
+    }
+}

--- a/test/resourceref/resourceref.test.ts
+++ b/test/resourceref/resourceref.test.ts
@@ -1,0 +1,46 @@
+import * as http from 'http';
+
+import * as chai from 'chai';
+
+// Chai is bad with types. See:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19480
+import chaiHttp = require('chai-http');
+chai.use(chaiHttp);
+
+import * as server from '../../src/server';
+import * as db from '../../src/db';
+
+const should = chai.should();
+
+describe('clusters', async() => {
+  let srv: http.Server;
+  before(async() => {
+    process.env.LOAD_METHOD = 'fs';
+    process.env.DATAFILES_FILE = 'test/resourceref/data.json';
+    const app = await server.appFromBundle(db.getInitialBundles());
+    srv = app.listen({ port: 4000 });
+  });
+
+  it('resolve resource refs', async() => {
+    const query = `
+      {
+        test: test_type_v1 {
+          name
+          unresolvable_resource_ref
+          resolvable_resource_ref {
+            content
+          }
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+                        .post('/graphql')
+                        .set('content-type', 'application/json')
+                        .send({ query });
+    resp.should.have.status(200);
+    resp.body.extensions.schemas.should.eql(['/test-type-1.yml']);
+    resp.body.data.test[0].name.should.equal('name');
+    resp.body.data.test[0].unresolvable_resource_ref.should.equal('/resource1.yml');
+    return resp.body.data.test[0].resolvable_resource_ref.content.should.equal('test resource');
+  });
+});


### PR DESCRIPTION
### Problem

resource files are somehow detached from our regular graphql types. they are just references as a path and it is up to the respective integration to fetch the content of such a resource with a dedicated query. this consumes a lot of time during integration runs and pr checks, because such resources are fetched one by one (see terraform-resources defaults or jjb config_path).

### Implementation idea

`isResource`field definition enhanced with `resolveResource: true` will be queryable as graphql type `Resource_v1`

### Example

schema.yml

```yaml
- name: JenkinsConfig_v1
  fields:
    ...
    - { name: config_path, type: string, isResource: true, resolveResource: true }
```

query

```
{
  jenkins_configs: jenkins_configs_v1 {
    name
    ...
    type
    config
    config_path {
      content
      sha256sum
    }
  }
}
```

ref: https://issues.redhat.com/browse/APPSRE-5950

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>