### PR TITLE
Update image from centos:7 to ubi8 and nodejs 10 to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,9 @@
-FROM quay.io/centos/centos:7
+FROM registry.access.redhat.com/ubi8/nodejs-16
 
-# Set PATH, because "scl enable" does not have any effects to "docker build"
-ENV PATH /opt/rh/rh-nodejs10/root/usr/bin:$PATH
+RUN npm install -g yarn
 
-# enable scl with nodejs8
-RUN yum install centos-release-scl-rh -y && \
-    yum install rh-nodejs10 rh-nodejs10-npm -y && \
-    yum clean all && \
-    npm install -g yarn
-
-ENV APP_ROOT /opt/qontract-server
 ADD . ${APP_ROOT}
 WORKDIR ${APP_ROOT}
-
-RUN adduser qontract
-RUN chown -R qontract /opt/qontract-server
-USER qontract
-
-ENV PATH /opt/rh/rh-nodejs10/root/usr/bin:$PATH
 
 RUN yarn install && yarn build
 

--- a/Dockerfiletest
+++ b/Dockerfiletest
@@ -1,15 +1,7 @@
-FROM quay.io/centos/centos:7
+FROM registry.access.redhat.com/ubi8/nodejs-16
 
-# Set PATH, because "scl enable" does not have any effects to "docker build"
-ENV PATH /opt/rh/rh-nodejs10/root/usr/bin:$PATH
+RUN npm install -g yarn
 
-# enable scl with nodejs8
-RUN yum install centos-release-scl-rh -y && \
-    yum install rh-nodejs10 rh-nodejs10-npm -y && \
-    yum clean all && \
-    npm install -g yarn
-
-ENV APP_ROOT /opt/qontract-server
 ADD . ${APP_ROOT}
 WORKDIR ${APP_ROOT}
 


### PR DESCRIPTION
The primary goal of this PR was to move the image to UBI 8

The PR also uses the NodeJS flavor of the UBI image. While researching this I realized the version we are currently using (10.x) has reached end of life over a year ago. 

Nodejs 10 and 12 have both reached end of life. Nodejs 14 will reach end of life in less than a year. NodeJS 16 is the current LTS version.

Using the NodeJS flavor also simplified the Dockerfile and the packages that were required

I've done tests locally
- qontract-server starts fine
- the `/graphql` endpoint works and running queries workm and return expected results
- the `/reload` endpoint worked

This also closes #84 
