### PR TITLE
Target both DC and D workloads

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -361,7 +361,7 @@ objects:
         port: 8080
         targetPort: 8080
     selector:
-      deploymentconfig: app-interface
+      status: migrating
 - apiVersion: v1
   kind: Service
   metadata:
@@ -375,7 +375,7 @@ objects:
         targetPort: 4000
         name: app-interface
     selector:
-      deploymentconfig: app-interface
+      status: migrating
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/qontract-server


### PR DESCRIPTION
Continuation of migration effort to `Deployment` workload. This change will begin routing traffic to both workloads so that new `Deployment` can be verified.

Ticket: https://issues.redhat.com/browse/APPSRE-5932