### PR TITLE
Revert "target both DC and D workloads (#155)"

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -361,7 +361,7 @@ objects:
         port: 8080
         targetPort: 8080
     selector:
-      status: migrating
+      deploymentconfig: app-interface
 - apiVersion: v1
   kind: Service
   metadata:
@@ -375,7 +375,7 @@ objects:
         targetPort: 4000
         name: app-interface
     selector:
-      status: migrating
+      deploymentconfig: app-interface
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/qontract-server


### PR DESCRIPTION
This reverts commit 0326a16b617f71b40bf1d2ab62f57ae0717e738a.

Monitoring of `sd-app-sre-reconcile-stage`'s consistent output since merge has reduced confidence in using this approach. 