### PR TITLE
simplify diff exposure between two bundles

### DIFF
--- a/test/diff/diff.test.ts
+++ b/test/diff/diff.test.ts
@@ -36,19 +36,12 @@ describe('diff', async() => {
     resp.should.have.status(200);
     logger.info(JSON.stringify(resp.body));
 
-    resp.body.length.should.equal(2);
-
-    const changed = resp.body[0];
+    const changed = resp.body.datafiles['/cluster.yml'];
     changed.datafilepath.should.equal('/cluster.yml');
     changed.datafileschema.should.equal('/openshift/cluster-1.yml');
-    changed.action.should.equal('E');
-    changed.jsonpath.should.equal('important.resource');
 
-    const resource = resp.body[1];
-    resource.datafilepath.should.equal('/cluster.yml');
-    resource.datafileschema.should.equal('/openshift/cluster-1.yml');
-    resource.action.should.equal('E');
-    resource.jsonpath.should.equal('automationToken.path');
+    const resource = resp.body.resources['/changed_resource.yml'];
+    resource.resourcepath.should.equal('/changed_resource.yml');
   });
 
   after(() => {


### PR DESCRIPTION
javascript diffing capabilities are limited and some corner cases can't be covered to detect proper structural diffs, e.g. adding or removing array elements in places other than the end of the array yields a lot of fake changes.

therefore the diff endpoint output has been simplified. it does not report fine grained changes for datafiles and resources anymore but instead exposes only the changes files with some metadata. it is up to the user of the diff endpoint to look for specific changes within the old and new state of a datafile or resource.

this is a breaking change for the endpoint because the change path details have been removed. but since this endpoint is not in use yet, changing it is legit.

in python the deep-diff library is capable to detect all those changes in a stable way (even list reorderings etc.)

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>