### PR TITLE
fix memory leak when removing expired bundles

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -85,6 +85,9 @@ const removeExpiredBundles = (app: express.Express) => {
 
       // remove from searchableFields
       delete app.get('searchableFields')[sha];
+
+      // remove from datafileSchemas
+      delete app.get('datafileSchemas')[sha]
     }
   }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,7 +87,7 @@ const removeExpiredBundles = (app: express.Express) => {
       delete app.get('searchableFields')[sha];
 
       // remove from datafileSchemas
-      delete app.get('datafileSchemas')[sha]
+      delete app.get('datafileSchemas')[sha];
     }
   }
 };


### PR DESCRIPTION
the cached datafileSchemas were not removed when its bundle expired.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>