### PR TITLE
fix more memory leaks and avoid unnecessary interface resolver functions

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -285,10 +285,14 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
   );
 
   // interface
-  objTypeConf['interfaces'] = () => [
-    conf.interface ? getInterfaceType(app, bundleSha, conf.interface) : null,
-    conf.datafile ? getInterfaceType(app, bundleSha, 'DatafileObject_v1') : null,
-  ].filter(x => x != null);
+  if (conf.interface || conf.datafile) {
+    objTypeConf['interfaces'] = () => {
+      return [
+        conf.interface ? getInterfaceType(app, bundleSha, conf.interface) : null,
+        conf.datafile ? getInterfaceType(app, bundleSha, 'DatafileObject_v1') : null,
+      ].filter(x => x != null);
+    };
+  }
 
   // generate resolveType for interfaces
   if (conf.isInterface) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,12 @@ const removeExpiredBundles = (app: express.Express) => {
 
       // remove from datafileSchemas
       delete app.get('datafileSchemas')[sha];
+
+      // remove from objectTypes
+      delete app.get('objectTypes')[sha];
+
+      // remove from objectInterfaces
+      delete app.get('objectInterfaces')[sha];
     }
   }
 };


### PR DESCRIPTION
* objectTypes and objectInterfaces were not cleaned up on bundle expiration - this changes removes those cached objects on bundle expiration
* unnecessary interface resolver functions were created - this change only creates them for either types that really have interfaces or are a datafile and get the dynamic DatafileObject_v1 interface assigned

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>