### PR TITLE
non-nullable lists on isRequired

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -203,12 +203,13 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
         throw `fieldInfo type is undefined: ${JSON.stringify(fieldInfo)}`;
       }
 
-      if (fieldInfo.isRequired) {
-        t = new GraphQLNonNull(t);
+      if (fieldInfo.isList) {
+        // make list elements non nullable
+        t = new GraphQLList(GraphQLNonNull(t));
       }
 
-      if (fieldInfo.isList) {
-        t = new GraphQLList(t);
+      if (fieldInfo.isRequired) {
+        t = new GraphQLNonNull(t);
       }
 
       fieldDef['type'] = t;


### PR DESCRIPTION
this change renders lists non-nullable if `isRequired: true` is defined. this relates more the the `required` semantics of `jsonschema`. additonally, list elements will not be nullable, which is consistent with the way AppSRE uses jsonschema in `qontract-schema`

https://json-schema.org/understanding-json-schema/reference/object.html#required-properties

the `qenerate` generated gql dataclasses would reflect such a change as follows

### example of a not required list

```python
-    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saasFiles")
+    saas_files: Optional[list[SaasFileV2]] = Field(..., alias="saasFiles")
```

### example of a required list

```python
-    saas_files: Optional[list[SaasFileV2]] = Field(..., alias="saasFiles")
+    saas_files: list[SaasFileV2] = Field(..., alias="saasFiles")
```

Part of https://issues.redhat.com/browse/APPSRE-6153

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>