### PR TITLE
synthetic subAttr referencing nested fields, 2nd attempt

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -48,6 +48,12 @@ Fields associated with a given type can have different attributes. Let's explore
 
 `resolveResource`: This attribute can be put on a resource reference field (isResource: true and type: string) to replace fetching the path of an object with the actual resource object. This enables resource fetching without breaking schema changes
 
-`synthetic`: This attribute is used to set up backrefs which can be queried during runtime.
+`synthetic`: This attribute is used to set up backward references following a schema references back to the parent, e.g.
+
+```yaml
+synthetic:
+  schema: /parent-schema-1.yml,
+  subAttr: path to the field in the parent schema that points to >this< schema using . (dot) as path delimiter
+```
 
 `datafileSchema`: This attribute is used during filtering to ensure the query result is of required schema.

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -85,21 +85,16 @@ const resolveSyntheticField = (app: express.Express,
 
     if (datafile.$schema !== schema) { return false; }
 
-    if (subAttr in datafile) {
-      const subAttrVal = datafile[subAttr];
-
-      // the attribute is a list of $refs
-      if (Array.isArray(subAttrVal)) {
-        const backrefs = datafile[subAttr].map((r: any) => r.$ref);
-        return backrefs.includes(path);
-      }
-
-      // the attribute is a single $ref
-      if (subAttrVal.$ref === path) {
-        return true;
-      }
+    let resolutionContext = [datafile];
+    for (const field of subAttr.split('.')) {
+      resolutionContext = resolutionContext.map((c: any) => {
+        if (c && field in c) {
+          return c[field];
+        }
+        return null;
+      }).flat().filter((c: any) => c);
     }
-    return false;
+    return resolutionContext.map((c: any) => c.$ref).includes(path);
   }).values());
 
 // default resolver

--- a/test/synthetic/data.json
+++ b/test/synthetic/data.json
@@ -1,0 +1,116 @@
+{
+    "data": {
+        "/recipes/guillaumes-deluxe.yml": {
+            "$schema": "/cakerecipe-1.yml",
+            "name": "Guillaumes Delux",
+            "inventor": "Guillaume",
+            "shoppingList": {
+                "cost": "999",
+                "ingredients": [
+                    {
+                        "$ref": "/ingredients/unicorn.yml"
+                    },
+                    {
+                        "$ref": "/ingredients/pixiedust.yml"
+                    },
+                    {
+                        "$ref": "/ingredients/choloclate.yml"
+                    }
+                ]
+            }
+        },
+        "/ingredients/unicorn.yml": {
+            "$schema": "/ingredient-1.yml",
+            "name": "Unicorn"
+        },
+        "/ingredients/pixiedust.yml": {
+            "$schema": "/ingredient-1.yml",
+            "name": "Pixiedust"
+        },
+        "/ingredients/choloclate.yml": {
+            "$schema": "/ingredient-1.yml",
+            "name": "Chocolate"
+        },
+        "/ingredients/cheese.yml": {
+            "$schema": "/ingredient-1.yml",
+            "name": "Cheese"
+        }
+    },
+    "graphql": {
+        "$schema" : "/app-interface/graphql-schemas-1.yml",
+        "confs": [
+            {
+                "name": "CakeRecipe_v1",
+                "fields": [
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "name"
+                    },
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "inventor"
+                    },
+                    {
+                        "type": "ShoppingList_V1",
+                        "name": "shoppingList"
+                    }
+                ]
+            },
+            {
+                "name": "ShoppingList_V1",
+                "fields": [
+                    {
+                        "isRequired": true,
+                        "type": "int",
+                        "name": "cost"
+                    },
+                    {
+                        "isRequired": true,
+                        "isList": true,
+                        "type": "Ingredient_v1",
+                        "name": "ingredients"
+                    }
+                ]
+            },
+            {
+                "name": "Ingredient_v1",
+                "fields": [
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "name"
+                    },
+                    {
+                        "name": "recipes",
+                        "type": "CakeRecipe_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/cakerecipe-1.yml",
+                            "subAttr": "shoppingList.ingredients"
+                        }
+                    }
+                ]
+            },
+            {
+                "fields": [
+                    {
+                        "type": "CakeRecipe_v1",
+                        "name": "cakerecipe_v1",
+                        "isList": true,
+                        "datafileSchema": "/cakerecipe-1.yml"
+                    },
+                    {
+                        "type": "Ingredient_v1",
+                        "name": "ingredient_v1",
+                        "isList": true,
+                        "datafileSchema": "/ingredient-1.yml"
+                    }
+                ],
+                "name": "Query"
+            }
+        ]
+    },
+    "resources": {}
+}

--- a/test/synthetic/data.json
+++ b/test/synthetic/data.json
@@ -1,5 +1,14 @@
 {
     "data": {
+        "/collections/magical-cakes.yml": {
+            "$schema": "/recipecollection-1.yml",
+            "name": "Magical Cakes",
+            "recipes": [
+                {
+                    "$ref": "/recipes/guillaumes-deluxe.yml"
+                }
+            ]
+        },
         "/recipes/guillaumes-deluxe.yml": {
             "$schema": "/cakerecipe-1.yml",
             "name": "Guillaumes Delux",
@@ -40,6 +49,21 @@
         "$schema" : "/app-interface/graphql-schemas-1.yml",
         "confs": [
             {
+                "name": "RecipeCollection_v1",
+                "fields": [
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "name"
+                    },
+                    {
+                        "type": "CakeRecipe_v1",
+                        "name": "recipes",
+                        "isList": true
+                    }
+                ]
+            },
+            {
                 "name": "CakeRecipe_v1",
                 "fields": [
                     {
@@ -53,13 +77,22 @@
                         "name": "inventor"
                     },
                     {
-                        "type": "ShoppingList_V1",
+                        "type": "ShoppingList_v1",
                         "name": "shoppingList"
+                    },
+                    {
+                        "name": "recipeCollections",
+                        "type": "RecipeCollection_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/recipecollection-1.yml",
+                            "subAttr": "recipes"
+                        }
                     }
                 ]
             },
             {
-                "name": "ShoppingList_V1",
+                "name": "ShoppingList_v1",
                 "fields": [
                     {
                         "isRequired": true,
@@ -95,6 +128,12 @@
             },
             {
                 "fields": [
+                    {
+                        "type": "RecipeCollection_v1",
+                        "name": "recipecollection_v1",
+                        "isList": true,
+                        "datafileSchema": "/recipecollection-1.yml"
+                    },
                     {
                         "type": "CakeRecipe_v1",
                         "name": "cakerecipe_v1",

--- a/test/synthetic/synthetic.test.ts
+++ b/test/synthetic/synthetic.test.ts
@@ -21,6 +21,26 @@ describe('synthetic', async() => {
     srv = app.listen({ port: 4000 });
   });
 
+  it('resolves synthetics', async() => {
+    const query = `
+      {
+        test: cakerecipe_v1(path: "/recipes/guillaumes-deluxe.yml") {
+          name
+          recipeCollections {
+            name
+          }
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+                        .post('/graphql')
+                        .set('content-type', 'application/json')
+                        .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test[0].name.should.equal('Guillaumes Delux');
+    return resp.body.data.test[0].recipeCollections[0].name.should.equal('Magical Cakes');
+  });
+
   it('resolves nested synthetics', async() => {
     const query = `
       {

--- a/test/synthetic/synthetic.test.ts
+++ b/test/synthetic/synthetic.test.ts
@@ -1,0 +1,43 @@
+import * as http from 'http';
+
+import * as chai from 'chai';
+
+// Chai is bad with types. See:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19480
+import chaiHttp = require('chai-http');
+chai.use(chaiHttp);
+
+import * as server from '../../src/server';
+import * as db from '../../src/db';
+
+const should = chai.should();
+
+describe('synthetic', async() => {
+  let srv: http.Server;
+  before(async() => {
+    process.env.LOAD_METHOD = 'fs';
+    process.env.DATAFILES_FILE = 'test/synthetic/data.json';
+    const app = await server.appFromBundle(db.getInitialBundles());
+    srv = app.listen({ port: 4000 });
+  });
+
+  it('resolves nested synthetics', async() => {
+    const query = `
+      {
+        test: ingredient_v1(path: "/ingredients/pixiedust.yml") {
+          name
+          recipes {
+            name
+          }
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+                        .post('/graphql')
+                        .set('content-type', 'application/json')
+                        .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test[0].name.should.equal('Pixiedust');
+    return resp.body.data.test[0].recipes[0].name.should.equal('Guillaumes Delux');
+  });
+});


### PR DESCRIPTION
the `subAttr` field of a synthetic declaration is used as a foreign key to define the backreference relation to another schema.

this PR enables the `subAttr` field to declare this relation not only to top level fields of the referenced schema but also nested fields, using `.` (dot) as a separator for nesting levels.

Example

```
- name: StatusPage_v1
  fields:
  - name: components
    type: StatusPageComponent_v1
    isList: true
    synthetic:
      schema: /dependencies/status-page-component-1.yml
      subAttr: some.path.to.a.page
```

Will be used in https://github.com/app-sre/qontract-schemas/pull/189 to backreference between maintenances and the statuspage components that participate.

this feature was once introduced in #150 and reverted in #159 because it was (wrongly) suspected to be the culprit of qontract-server instabilities.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>