### PR TITLE
Remove all remaining CPU limits

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -121,7 +121,6 @@ objects:
               cpu: ${S3RELOADER_CPU_REQUESTS}
             limits:
               memory: ${S3RELOADER_MEMORY_LIMIT}
-              cpu: ${S3RELOADER_CPU_LIMIT}
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: app-interface
@@ -179,7 +178,6 @@ objects:
               cpu: ${CPU_REQUESTS}
             limits:
               memory: ${MEMORY_LIMIT}
-              cpu: ${CPU_LIMIT}
     triggers:
     - type: ConfigChange
 - apiVersion: v1
@@ -236,8 +234,6 @@ parameters:
   value: 512Mi
 - name: CPU_REQUESTS
   value: 30m
-- name: CPU_LIMIT
-  value: 60m
 
 # container 'app-interface-nginx-gate' resources
 - name: GATE_MEMORY_REQUESTS
@@ -246,8 +242,6 @@ parameters:
   value: 40Mi
 - name: GATE_CPU_REQUESTS
   value: 10m
-- name: GATE_CPU_LIMIT
-  value: 20m
 
 # container 's3-reloader' resources
 - name: S3RELOADER_MEMORY_REQUESTS
@@ -256,5 +250,3 @@ parameters:
   value: 40Mi
 - name: S3RELOADER_CPU_REQUESTS
   value: 5m
-- name: S3RELOADER_CPU_LIMIT
-  value: 10m


### PR DESCRIPTION
Following #166

CPU limits are proving to be harmful on q-s, throttling while CPU is not being maxed out.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>