### PR TITLE
provision deployment workload alongside deploymentconfig

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -305,15 +305,15 @@ objects:
               path: /healthz
               port: 4000
             initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 3
+            periodSeconds: 20
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz
               port: 4000
-            initialDelaySeconds: 3
-            periodSeconds: 10
-            timeoutSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 10
           resources: "${{APP_INTERFACE_RESOURCES}}"
 - apiVersion: v1
   kind: Service

--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -37,6 +37,7 @@ objects:
         labels:
           app: app-interface
           deploymentconfig: app-interface
+          status: migrating
       spec:
         affinity:
           podAntiAffinity:
@@ -165,6 +166,155 @@ objects:
           resources: "${{APP_INTERFACE_RESOURCES}}"
     triggers:
     - type: ConfigChange
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: app-interface
+    name: app-interface
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      matchLabels:
+        app: app-interface
+        deployment: app-interface
+    strategy:
+      rollingParams:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: app-interface
+          deployment: app-interface
+          status: migrating
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - app-interface
+                  topologyKey: kubernetes.io/hostname
+                weight: 90
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - app-interface
+                  topologyKey: topology.kubernetes.io/zone
+                weight: 100
+        containers:
+        - image: ${IMAGE_GATE}:${IMAGE_GATE_TAG}
+          imagePullPolicy: Always
+          name: app-interface-nginx-gate
+          env:
+            - name: HTPASSWD
+              valueFrom:
+                secretKeyRef:
+                    key: htpasswd
+                    name: app-interface
+            - name: FORWARD_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: forward_host
+                  name: app-interface
+          ports:
+          - name: nginx-gate-port
+            containerPort: 8080
+          resources: "${{GATE_RESOURCES}}"
+        - image: ${IMAGE_RELOADER}:${IMAGE_RELOADER_TAG}
+          imagePullPolicy: Always
+          name: s3-reloader
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                    key: aws.access.key.id
+                    name: app-interface
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                    key: aws.region
+                    name: app-interface
+            - name: AWS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                    key: aws.s3.bucket
+                    name: app-interface
+            - name: AWS_S3_KEY
+              valueFrom:
+                secretKeyRef:
+                    key: aws.s3.key
+                    name: app-interface
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                    key: aws.secret.access.key
+                    name: app-interface
+          args:
+          - -s3-path=s3://$(AWS_S3_BUCKET)/$(AWS_S3_KEY)
+          - -webhook-url=http://localhost:4000/reload
+          resources: "${{S3RELOADER_RESOURCES}}"
+        - image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          name: app-interface
+          env:
+            - name: LOAD_METHOD
+              valueFrom:
+                configMapKeyRef:
+                  key: load_method
+                  name: app-interface
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                    key: aws.access.key.id
+                    name: app-interface
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                    key: aws.region
+                    name: app-interface
+            - name: AWS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                    key: aws.s3.bucket
+                    name: app-interface
+            - name: AWS_S3_KEY
+              valueFrom:
+                secretKeyRef:
+                    key: aws.s3.key
+                    name: app-interface
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                    key: aws.secret.access.key
+                    name: app-interface
+          ports:
+          - name: app-interface
+            containerPort: 4000
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 4000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 4000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources: "${{APP_INTERFACE_RESOURCES}}"
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
This is part 1 of 2 to migrate qontract-server to a `Deployment` workload. 

This change will provision a `Deployment` with identical config to the existing DC but without adjusting the service selectors to target it. I.E, this workload will not receive any traffic until part 2 (alter services to select both workloads).

context from original approval: https://github.com/app-sre/qontract-server/pull/153

ticket: https://issues.redhat.com/browse/APPSRE-5932