### PR TITLE
Increase waiting times in probes

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -153,15 +153,15 @@ objects:
               path: /healthz
               port: 4000
             initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 3
+            periodSeconds: 20
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz
               port: 4000
-            initialDelaySeconds: 3
-            periodSeconds: 10
-            timeoutSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 10
           resources: "${{APP_INTERFACE_RESOURCES}}"
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
qontract-server freezes while reloading the bundling as parsing json is a blocking operation. While we fix that, we will need to increase the waiting times in the probes to avoid continuous restarts which are quite bad since data is stored in memory.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>