### PR TITLE
reduce runtime of resolveSyntheticField

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -75,7 +75,7 @@ const getGraphqlTypeForDatafileSchema = (app: express.Express, bundleSha: string
 // helpers
 const isNonEmptyArray = (obj: any) => obj.constructor === Array && obj.length > 0;
 
-const pathRefExistsinDatafile = (path: string, datafile: any,
+const pathRefExistsInDatafile = (path: string, datafile: any,
                                  subAttrs: string[],
                                  idx: number): boolean => {
   const leaf = idx === subAttrs.length - 1;
@@ -89,7 +89,7 @@ const pathRefExistsinDatafile = (path: string, datafile: any,
         return backrefs.includes(path);
       }
       for (const subAttrValItem of subAttrVal) {
-        if (pathRefExistsinDatafile(path, subAttrValItem, subAttrs, idx + 1)) {
+        if (pathRefExistsInDatafile(path, subAttrValItem, subAttrs, idx + 1)) {
           return true;
         }
       }
@@ -100,7 +100,7 @@ const pathRefExistsinDatafile = (path: string, datafile: any,
     if (leaf) {
       return subAttrVal.$ref === path;
     }
-    return pathRefExistsinDatafile(path, subAttrVal, subAttrs, idx + 1);
+    return pathRefExistsInDatafile(path, subAttrVal, subAttrs, idx + 1);
   }
   return false;
 };
@@ -115,7 +115,7 @@ const resolveSyntheticField = (app: express.Express,
 
     if (datafile.$schema !== schema) { return false; }
 
-    return pathRefExistsinDatafile(path, datafile, subAttr.split('.'), 0);
+    return pathRefExistsInDatafile(path, datafile, subAttr.split('.'), 0);
   }).values());
 
 // default resolver

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -78,6 +78,13 @@ const isNonEmptyArray = (obj: any) => obj.constructor === Array && obj.length > 
 const pathRefExistsInDatafile = (path: string, datafile: any,
                                  subAttrs: string[],
                                  idx: number): boolean => {
+  // this function is basically just a dumb and simplified version of the previous
+  // synthetic resolver, that does not want to be smart or elaborate and just
+  // implements all the different filtering cases as simple as possible,
+  // avoiding costly operations on large lists of objects for performance reasons.
+  //
+  // if anyone wants to beautify this code, make sure that performance is not
+  // negatively affected!!!
   const leaf = idx === subAttrs.length - 1;
   if (subAttrs[idx] in datafile) {
     const subAttrVal = datafile[subAttrs[idx]];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -75,9 +75,9 @@ const getGraphqlTypeForDatafileSchema = (app: express.Express, bundleSha: string
 // helpers
 const isNonEmptyArray = (obj: any) => obj.constructor === Array && obj.length > 0;
 
-const resolveSyntheticFieldInDatafile = (path: string, datafile: any,
-                                         subAttrs: string[],
-                                         idx: number): boolean => {
+const pathRefExistsinDatafile = (path: string, datafile: any,
+                                 subAttrs: string[],
+                                 idx: number): boolean => {
   const leaf = idx === subAttrs.length - 1;
   if (subAttrs[idx] in datafile) {
     const subAttrVal = datafile[subAttrs[idx]];
@@ -89,7 +89,7 @@ const resolveSyntheticFieldInDatafile = (path: string, datafile: any,
         return backrefs.includes(path);
       }
       for (const subAttrValItem of subAttrVal) {
-        if (resolveSyntheticFieldInDatafile(path, subAttrValItem, subAttrs, idx + 1)) {
+        if (pathRefExistsinDatafile(path, subAttrValItem, subAttrs, idx + 1)) {
           return true;
         }
       }
@@ -100,7 +100,7 @@ const resolveSyntheticFieldInDatafile = (path: string, datafile: any,
     if (leaf) {
       return subAttrVal.$ref === path;
     }
-    return resolveSyntheticFieldInDatafile(path, subAttrVal, subAttrs, idx + 1);
+    return pathRefExistsinDatafile(path, subAttrVal, subAttrs, idx + 1);
   }
   return false;
 };
@@ -115,7 +115,7 @@ const resolveSyntheticField = (app: express.Express,
 
     if (datafile.$schema !== schema) { return false; }
 
-    return resolveSyntheticFieldInDatafile(path, datafile, subAttr.split('.'), 0);
+    return pathRefExistsinDatafile(path, datafile, subAttr.split('.'), 0);
   }).values());
 
 // default resolver

--- a/test/synthetic/data.json
+++ b/test/synthetic/data.json
@@ -43,6 +43,24 @@
         "/ingredients/cheese.yml": {
             "$schema": "/ingredient-1.yml",
             "name": "Cheese"
+        },
+        "/stores/magical-ingredients-inc.yml": {
+            "$schema": "/store-1.yml",
+            "name": "Magical Ingredients Inc."
+        },
+        "/shoppinglists/birthday-party.yml": {
+            "$schema": "/shoppinglist-1.yml",
+            "name": "Birthday Party",
+            "cost": "999",
+            "ingredients": [
+                {
+                    "$schema": "/ingredient-1.yml",
+                    "name": "Pixiedust",
+                    "store": {
+                        "$ref": "/stores/magical-ingredients-inc.yml"
+                    }
+                }
+            ]
         }
     },
     "graphql": {
@@ -60,6 +78,25 @@
                         "type": "CakeRecipe_v1",
                         "name": "recipes",
                         "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "Store_v1",
+                "fields": [
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "name"
+                    },
+                    {
+                        "name": "shoppingLists",
+                        "type": "ShoppingList_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/shoppinglist-1.yml",
+                            "subAttr": "ingredients.store"
+                        }
                     }
                 ]
             },
@@ -96,6 +133,11 @@
                 "fields": [
                     {
                         "isRequired": true,
+                        "type": "string",
+                        "name": "name"
+                    },
+                    {
+                        "isRequired": true,
                         "type": "int",
                         "name": "cost"
                     },
@@ -114,6 +156,10 @@
                         "isRequired": true,
                         "type": "string",
                         "name": "name"
+                    },
+                    {
+                        "type": "Store_v1",
+                        "name": "store"
                     },
                     {
                         "name": "recipes",
@@ -145,6 +191,18 @@
                         "name": "ingredient_v1",
                         "isList": true,
                         "datafileSchema": "/ingredient-1.yml"
+                    },
+                    {
+                        "type": "Store_v1",
+                        "name": "store_v1",
+                        "isList": true,
+                        "datafileSchema": "/store-1.yml"
+                    },
+                    {
+                        "type": "ShoppingList_v1",
+                        "name": "shoppinglist_v1",
+                        "isList": true,
+                        "datafileSchema": "/shoppinglist-1.yml"
                     }
                 ],
                 "name": "Query"

--- a/test/synthetic/synthetic.test.ts
+++ b/test/synthetic/synthetic.test.ts
@@ -41,7 +41,7 @@ describe('synthetic', async() => {
     return resp.body.data.test[0].recipeCollections[0].name.should.equal('Magical Cakes');
   });
 
-  it('resolves nested synthetics', async() => {
+  it('resolves nested synthetics with lists as leaf elements', async() => {
     const query = `
       {
         test: ingredient_v1(path: "/ingredients/pixiedust.yml") {
@@ -59,5 +59,25 @@ describe('synthetic', async() => {
     resp.should.have.status(200);
     resp.body.data.test[0].name.should.equal('Pixiedust');
     return resp.body.data.test[0].recipes[0].name.should.equal('Guillaumes Delux');
+  });
+
+  it('resolves nested synthetics with an object as leaf element', async() => {
+    const query = `
+      {
+        test: store_v1(path: "/stores/magical-ingredients-inc.yml") {
+          name
+          shoppingLists {
+            name
+          }
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+                        .post('/graphql')
+                        .set('content-type', 'application/json')
+                        .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test[0].name.should.equal('Magical Ingredients Inc.');
+    return resp.body.data.test[0].shoppingLists[0].name.should.equal('Birthday Party');
   });
 });


### PR DESCRIPTION
this implementation of the synthetic field resolver is not as clean as the previous one but runs a lot faster, which is crucial for the nodejs eventloop to not block.

### example 1
* simple subAttr field - query apps and their namespaces via synthetic relation
* old implementation: 245-300ms
* new implementation: 164-195ms

### example 2
* nested subAttr field - query saasfiles and their selfServiceRoles via the synthetic relation
* old implementation: 440-640ms
* new implementation: 320-375ms

this chagne is part of multiple approaches to unblock the nodejs event loop

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>