### PR TITLE
target deployment exclusively

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -325,7 +325,7 @@ objects:
         port: 8080
         targetPort: 8080
     selector:
-      status: migrating
+      deployment: app-interface
 - apiVersion: v1
   kind: Service
   metadata:
@@ -339,7 +339,7 @@ objects:
         targetPort: 4000
         name: app-interface
     selector:
-      status: migrating
+      deployment: app-interface
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/qontract-server


### PR DESCRIPTION
This will "fan-in" the app-interface service and route 100% of traffic to new `Deployment` workload

follow up to https://github.com/app-sre/qontract-server/pull/173