### PR TITLE
rename to comply with max character limit of 15

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -137,12 +137,12 @@ objects:
           - -s3-path=s3://$(AWS_S3_BUCKET)/$(AWS_S3_KEY)
           - -webhook-url=http://localhost:4000/reload
           ports:
-          - name: s3-reloader-metrics
+          - name: s3-reloader
             containerPort: 9533
           livenessProbe:
             httpGet:
               path: /metrics
-              port: s3-reloader-metrics
+              port: s3-reloader
               scheme: HTTP
             failureThreshold: 3
             periodSeconds: 10


### PR DESCRIPTION
Addresses `livenessProbe.httpGet.port: Invalid value: "s3-reloader-metrics": must be no more than 15 characters`