### PR TITLE
remove mandatory flag from datafileobject in tests

### DIFF
--- a/test/datafileobject/data.json
+++ b/test/datafileobject/data.json
@@ -37,8 +37,7 @@
                 "fields": [
                     {
                         "name": "path",
-                        "type": "string",
-                        "isRequired": true
+                        "type": "string"
                     },
                     {
                         "name": "schema",


### PR DESCRIPTION
all datafiles have a path. that is something qontract-server makes sure by setting the path field for each loaded datafile from the bundle. from a schema perspective, we can make the path field optional so it works better with embedded types like saas-file-target-v1.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>