### PR TITLE
diff endpoint for single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The shas will expire after a certain amount of time:
 - `GET /metrics`: prometheus metrics.
 - `GET /git-commit`: returns the git commit for the latest bundle. (deprecated, use git-commit-info instead)
 - `GET /git-commit/:sha`: returns the git commit for the specified bundle., use git-commit-info instead
+- `GET /diff/:sha/:another_sha`: return the difference between two bundles
+- `GET /diff/:sha/:another_sha/:filetype/:path`: return the difference for a single `datafile` or `resourcefile`
 
 ## Metrics
 


### PR DESCRIPTION
to support some advanced change-type processes in qontract-reconciles change-owner integration (hopping multiple files to expand ownership for reusable change-types), a flavour of the existing diff endpoint is introduced to allow fetching diffs for an individual datafile or resourcefile.

`GET /diff/:sha/:another_sha/:filetype/:path` where `filetype` is `datafile` or `resourcefile`

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>