### PR TITLE
openshift template PodDisruptionBudget version fix

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -8,7 +8,7 @@ objects:
   kind: ServiceAccount
   metadata:
     name: app-interface
-- apiVersion: policy/v1beta1
+- apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:
     name: app-interface


### PR DESCRIPTION
use v1 as the version for the PodDisruptionBudget since v1beta1 is not available anymore

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>