### PR TITLE
Update .dockerignore for file permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git
 .env
-dist/*
-node_modules/*
+dist
+node_modules
+bundle


### PR DESCRIPTION
Update `.dockerignore` to avoid file permission issues like 
```
error An unexpected error occurred: "EACCES: permission denied, mkdir '/opt/app-root/node_modules/accepts'".
```
when running `make build` after `yarn install`.

Signed-off-by: Di Wang <dwan@redhat.com>