### PR TITLE
Further improve performance of synthetic and datafileSchema resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ bundle:
 run:
 	LOAD_METHOD=fs DATAFILES_FILE=$(BUNDLE_DIR)/$(BUNDLE_FILENAME) yarn run server
 
+debug:
+	LOAD_METHOD=fs DATAFILES_FILE=$(BUNDLE_DIR)/$(BUNDLE_FILENAME) yarn run debug
+
 docker-run:
 	@$(CONTAINER_ENGINE) run -it --rm --name $(SERVER_CONTAINER_NAME) \
 		-v $(BUNDLE_DIR):/bundle$(CONTAINER_SELINUX_FLAG) \

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "server": "node ./dist/main-bundle.js",
     "lint": "./node_modules/.bin/tslint --project .",
     "test": "mocha -r ts-node/register $(find test -type f -name '*.ts')",
-    "update-graphql-schema": "scripts/update-graphql-schema.js test/graphql_schema.json $(find test -name '*.data.json')"
+    "update-graphql-schema": "scripts/update-graphql-schema.js test/graphql_schema.json $(find test -name '*.data.json')",
+    "debug": "node --inspect --require ts-node/register src/server.ts"
   },
   "dependencies": {
     "apollo-server-express": "^2.18.0",

--- a/src/db.ts
+++ b/src/db.ts
@@ -36,6 +36,7 @@ export type Resourcefile = {
 
 export type Bundle = {
   datafiles: im.Map<string, Datafile>;
+  datafilesBySchema: im.Seq.Keyed<string, im.Collection<string, Datafile>>;
   resourcefiles: im.Map<string, Resourcefile>;
   schema: GraphQLSchemaType | any[];
   fileHash: string;
@@ -76,9 +77,11 @@ export const resolveRef = (bundle: Bundle, itemRef: Referencing) : any => {
 
 const parseBundle = (contents: string) : Bundle => {
   const parsedContents = JSON.parse(contents);
-
+  const datafiles = parseDatafiles(parsedContents.data);
+  const datafilesBySchema = datafiles.groupBy(d => d.$schema);
   return {
-    datafiles: parseDatafiles(parsedContents.data),
+    datafiles,
+    datafilesBySchema,
     resourcefiles: parseResourcefiles(parsedContents.resources),
     fileHash: hashDatafile(contents),
     gitCommit: parsedContents['git_commit'],

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -73,43 +73,6 @@ const getGraphqlTypeForDatafileSchema = (app: express.Express, bundleSha: string
 // helpers
 const isNonEmptyArray = (obj: any) => obj.constructor === Array && obj.length > 0;
 
-const pathRefExistsInDatafile = (path: string, datafile: any,
-                                 subAttrs: string[],
-                                 idx: number): boolean => {
-  // this function is basically just a dumb and simplified version of the previous
-  // synthetic resolver, that does not want to be smart or elaborate and just
-  // implements all the different filtering cases as simple as possible,
-  // avoiding costly operations on large lists of objects for performance reasons.
-  //
-  // if anyone wants to beautify this code, make sure that performance is not
-  // negatively affected!!!
-  const leaf = idx === subAttrs.length - 1;
-  if (subAttrs[idx] in datafile) {
-    const subAttrVal = datafile[subAttrs[idx]];
-
-    // the attribute is a list of $refs
-    if (Array.isArray(subAttrVal)) {
-      if (leaf) {
-        const backrefs = datafile[subAttrs[idx]].map((r: any) => r.$ref);
-        return backrefs.includes(path);
-      }
-      for (const subAttrValItem of subAttrVal) {
-        if (pathRefExistsInDatafile(path, subAttrValItem, subAttrs, idx + 1)) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    // the attribute is a single $ref
-    if (leaf) {
-      return subAttrVal.$ref === path;
-    }
-    return pathRefExistsInDatafile(path, subAttrVal, subAttrs, idx + 1);
-  }
-  return false;
-};
-
 // synthetic field resolver
 const resolveSyntheticField = (bundle: db.Bundle,
                                path: string,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -113,12 +113,14 @@ const pathRefExistsInDatafile = (path: string, datafile: any,
 const resolveSyntheticField = (bundle: db.Bundle,
                                path: string,
                                schema: string,
-                               subAttr: string): db.Datafile[] =>
-    bundle.datafilesBySchema
-        .get(schema)
-        .filter((datafile: db.Datafile) => pathRefExistsInDatafile(path, datafile, subAttr.split('.'), 0))
-        .valueSeq()
-        .toArray();
+                               subAttr: string): db.Datafile[] => {
+  const attrs = subAttr.split('.');
+  return bundle.datafilesBySchema
+      .get(schema)
+      .filter((df: db.Datafile) => bundle.syntheticBackRefTrie.contains(df.path, attrs, path))
+      .valueSeq()
+      .toArray();
+};
 
 const resolveDatafileSchemaField = (bundle: db.Bundle,
                                     schema: string,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -118,12 +118,10 @@ const resolveSyntheticField = (app: express.Express,
                                path: string,
                                schema: string,
                                subAttr: string): db.Datafile[] =>
-  Array.from(app.get('bundles')[bundleSha].datafiles.filter((datafile: any) => {
-
-    if (datafile.$schema !== schema) { return false; }
-
-    return pathRefExistsInDatafile(path, datafile, subAttr.split('.'), 0);
-  }).values());
+  app.get('bundles')[bundleSha].datafilesBySchema.get(schema)
+      .filter((datafile: db.Datafile) => pathRefExistsInDatafile(path, datafile, subAttr.split('.'), 0))
+      .valueSeq()
+      .toArray();
 
 // default resolver
 export const defaultResolver = (app: express.Express, bundleSha: string) =>

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,19 +1,20 @@
 import * as express from 'express';
 
 import {
-  GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLString,
-  GraphQLFloat,
   GraphQLBoolean,
+  GraphQLFloat,
   GraphQLInt,
+  GraphQLInterfaceType,
   GraphQLList,
   GraphQLNonNull,
-  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLSchema,
+  GraphQLString,
 } from 'graphql';
 
 import * as db from './db';
+import { Datafile } from './types';
 
 const isRef = (obj: Object): boolean => {
   return obj.constructor === Object && Object.keys(obj).length === 1 && '$ref' in obj;
@@ -113,21 +114,15 @@ const pathRefExistsInDatafile = (path: string, datafile: any,
 const resolveSyntheticField = (bundle: db.Bundle,
                                path: string,
                                schema: string,
-                               subAttr: string): db.Datafile[] => {
-  const attrs = subAttr.split('.');
-  return bundle.datafilesBySchema
-      .get(schema)
-      .filter((df: db.Datafile) => bundle.syntheticBackRefTrie.contains(df.path, attrs, path))
-      .valueSeq()
-      .toArray();
-};
+                               subAttr: string): Datafile[] =>
+  bundle.syntheticBackRefTrie.getDatafiles(schema, subAttr.split('.'), path);
 
 const resolveDatafileSchemaField = (bundle: db.Bundle,
                                     schema: string,
-                                    args: any): db.Datafile[] =>
+                                    args: any): Datafile[] =>
     bundle.datafilesBySchema
         .get(schema)
-        .filter((df: db.Datafile) => Object.entries(args)
+        .filter((df: Datafile) => Object.entries(args)
             .every(([key, value]) => key in df && value === df[key]))
         .valueSeq()
         .toArray();

--- a/src/syntheticBackRefTrie.ts
+++ b/src/syntheticBackRefTrie.ts
@@ -1,47 +1,49 @@
-class SyntheticBackRefTrieNode {
-  public readonly value: Set<string>;
-  public readonly children: Map<string, SyntheticBackRefTrieNode>;
+import { Collection, Seq } from 'immutable';
+import { Datafile, GraphQLSchemaType } from './types';
+
+class TrieNode {
+  public readonly value: Map<string, Set<Datafile>>;
+  public readonly children: Map<string, TrieNode>;
 
   constructor() {
-    this.value = new Set();
+    this.value = new Map();
     this.children = new Map();
   }
 
-  insert(attrs: string[], data: any) {
+  insert(keys: string[], data: any, value: Datafile) {
     if (Array.isArray(data)) {
-      for (const v of data) {
-        this.insert(attrs, v);
+      for (const d of data) {
+        this.insert(keys, d, value);
       }
       return;
     }
 
-    if (data == null || typeof data !== 'object') {
-      return;
-    }
-
-    if (attrs.length === 0) {
-      const v = data.$ref;
-      if (v) {
-        this.value.add(v);
+    if (keys.length === 0) {
+      if (typeof data !== 'string') {
+        return;
+      }
+      const values = this.value.get(data);
+      if (values === undefined) {
+        this.value.set(data, new Set([value]));
+      } else {
+        values.add(value);
       }
       return;
     }
 
-    const [head, ...rest] = attrs;
+    const [head, ...rest] = keys;
+    if (!(head in data)) {
+      return;
+    }
     const attrVal = data[head];
-
-    if (attrVal === undefined) {
-      return;
-    }
-
     const node = this.children.get(head);
     if (node !== undefined) {
-      node.insert(rest, attrVal);
+      node.insert(rest, attrVal, value);
       return;
     }
 
-    const newNode = new SyntheticBackRefTrieNode();
-    newNode.insert(rest, attrVal);
+    const newNode = new TrieNode();
+    newNode.insert(rest, attrVal, value);
     if (newNode.children.size > 0 || newNode.value.size > 0) {
       this.children.set(head, newNode);
     }
@@ -49,32 +51,73 @@ class SyntheticBackRefTrieNode {
 }
 
 export class SyntheticBackRefTrie {
-  private readonly root: SyntheticBackRefTrieNode;
+  private readonly root: TrieNode;
 
   constructor() {
-    this.root = new SyntheticBackRefTrieNode();
+    this.root = new TrieNode();
   }
 
-  insert(path: string, attrs: string[], data: any) {
-    const node = this.root.children.get(path);
-
-    if (node !== undefined) {
-      node.insert(attrs, data);
-      return;
-    }
-
-    const newNode = new SyntheticBackRefTrieNode();
-    newNode.insert(attrs, data);
-    if (newNode.children.size > 0 || newNode.value.size > 0) {
-      this.root.children.set(path, newNode);
-    }
+  insert(schema: string, attrs: string[], data: Datafile) {
+    const keys = [schema, ...attrs, '$ref'];
+    this.root.insert(keys, { [schema]: data }, data);
   }
 
-  contains(path: string, attrs: string[], ref: string): boolean {
-    let node = this.root.children.get(path);
-    for (const attr of attrs) {
-      node = node?.children.get(attr);
+  private find(keys: string[]): TrieNode | undefined {
+    let node = this.root;
+    for (const key of keys) {
+      node = node.children.get(key);
+      if (node === undefined) {
+        return undefined;
+      }
     }
-    return node === undefined ? false : node.value.has(ref);
+    return node;
+  }
+
+  getDatafiles(schema: string, attrs: string[], path: string): Datafile[] {
+    const keys = [schema, ...attrs, '$ref'];
+    const node = this.find(keys);
+    if (node === undefined) {
+      return [];
+    }
+    const datafiles = node.value.get(path);
+    return datafiles === undefined ? [] : Array.from(datafiles);
   }
 }
+
+const getSyntheticFieldSubAttrsBySchema = (
+  schema: GraphQLSchemaType | any[],
+): Map<string, Set<string>> => {
+  const syntheticFieldSubAttrs = new Map<string, Set<string>>();
+  const schemaData = 'confs' in schema && schema.confs ? schema.confs : schema as any[];
+  for (const conf of schemaData) {
+    for (const fieldInfo of conf.fields) {
+      if (fieldInfo.synthetic) {
+        const key = fieldInfo.synthetic.schema;
+        const value = fieldInfo.synthetic.subAttr;
+        const subAttrs = syntheticFieldSubAttrs.get(key);
+        if (subAttrs === undefined) {
+          syntheticFieldSubAttrs.set(key, new Set([value]));
+        } else {
+          subAttrs.add(value);
+        }
+      }
+    }
+  }
+  return syntheticFieldSubAttrs;
+};
+
+export const buildSyntheticBackRefTrie = (
+  datafilesBySchema: Seq.Keyed<string, Collection<string, Datafile>>,
+  schema: GraphQLSchemaType | any[],
+): SyntheticBackRefTrie => {
+  const syntheticBackRefTrie = new SyntheticBackRefTrie();
+  const syntheticFieldSubAttrsBySchema = getSyntheticFieldSubAttrsBySchema(schema);
+  syntheticFieldSubAttrsBySchema.forEach((subAttrs: Set<string>, s: string) => {
+    (datafilesBySchema.get(s) || []).forEach((df: Datafile) => {
+      for (const subAttr of subAttrs) {
+        syntheticBackRefTrie.insert(s, subAttr.split('.'), df);
+      }
+    });
+  });
+  return syntheticBackRefTrie;
+};

--- a/src/syntheticBackRefTrie.ts
+++ b/src/syntheticBackRefTrie.ts
@@ -1,0 +1,80 @@
+class SyntheticBackRefTrieNode {
+  public readonly value: Set<string>;
+  public readonly children: Map<string, SyntheticBackRefTrieNode>;
+
+  constructor() {
+    this.value = new Set();
+    this.children = new Map();
+  }
+
+  insert(attrs: string[], data: any) {
+    if (Array.isArray(data)) {
+      for (const v of data) {
+        this.insert(attrs, v);
+      }
+      return;
+    }
+
+    if (data == null || typeof data !== 'object') {
+      return;
+    }
+
+    if (attrs.length === 0) {
+      const v = data.$ref;
+      if (v) {
+        this.value.add(v);
+      }
+      return;
+    }
+
+    const [head, ...rest] = attrs;
+    const attrVal = data[head];
+
+    if (attrVal === undefined) {
+      return;
+    }
+
+    const node = this.children.get(head);
+    if (node !== undefined) {
+      node.insert(rest, attrVal);
+      return;
+    }
+
+    const newNode = new SyntheticBackRefTrieNode();
+    newNode.insert(rest, attrVal);
+    if (newNode.children.size > 0 || newNode.value.size > 0) {
+      this.children.set(head, newNode);
+    }
+  }
+}
+
+export class SyntheticBackRefTrie {
+  private readonly root: SyntheticBackRefTrieNode;
+
+  constructor() {
+    this.root = new SyntheticBackRefTrieNode();
+  }
+
+  insert(path: string, attrs: string[], data: any) {
+    const node = this.root.children.get(path);
+
+    if (node !== undefined) {
+      node.insert(attrs, data);
+      return;
+    }
+
+    const newNode = new SyntheticBackRefTrieNode();
+    newNode.insert(attrs, data);
+    if (newNode.children.size > 0 || newNode.value.size > 0) {
+      this.root.children.set(path, newNode);
+    }
+  }
+
+  contains(path: string, attrs: string[], ref: string): boolean {
+    let node = this.root.children.get(path);
+    for (const attr of attrs) {
+      node = node?.children.get(attr);
+    }
+    return node === undefined ? false : node.value.has(ref);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export type Datafile = {
+  $schema: string;
+  path: string;
+  [key: string]: any;
+};
+
+export type GraphQLSchemaType = {
+  $schema: string;
+  confs: any[];
+};

--- a/test/synthetic/data.json
+++ b/test/synthetic/data.json
@@ -6,6 +6,9 @@
             "recipes": [
                 {
                     "$ref": "/recipes/guillaumes-deluxe.yml"
+                },
+                {
+                    "$ref": "/recipes/guillaumes-deluxe.yml"
                 }
             ]
         },

--- a/test/synthetic/synthetic.test.ts
+++ b/test/synthetic/synthetic.test.ts
@@ -37,8 +37,19 @@ describe('synthetic', async() => {
                         .set('content-type', 'application/json')
                         .send({ query });
     resp.should.have.status(200);
-    resp.body.data.test[0].name.should.equal('Guillaumes Delux');
-    return resp.body.data.test[0].recipeCollections[0].name.should.equal('Magical Cakes');
+    const expectedData = {
+      test: [
+        {
+          name: 'Guillaumes Delux',
+          recipeCollections: [
+            {
+              name: 'Magical Cakes',
+            },
+          ],
+        },
+      ],
+    };
+    resp.body.data.should.deep.equal(expectedData);
   });
 
   it('resolves nested synthetics with lists as leaf elements', async() => {
@@ -57,8 +68,15 @@ describe('synthetic', async() => {
                         .set('content-type', 'application/json')
                         .send({ query });
     resp.should.have.status(200);
-    resp.body.data.test[0].name.should.equal('Pixiedust');
-    return resp.body.data.test[0].recipes[0].name.should.equal('Guillaumes Delux');
+    const expectedData = {
+      test: [{
+        name: 'Pixiedust',
+        recipes: [{
+          name: 'Guillaumes Delux',
+        }],
+      }],
+    };
+    resp.body.data.should.deep.equal(expectedData);
   });
 
   it('resolves nested synthetics with an object as leaf element', async() => {
@@ -77,7 +95,14 @@ describe('synthetic', async() => {
                         .set('content-type', 'application/json')
                         .send({ query });
     resp.should.have.status(200);
-    resp.body.data.test[0].name.should.equal('Magical Ingredients Inc.');
-    return resp.body.data.test[0].shoppingLists[0].name.should.equal('Birthday Party');
+    const expectedData = {
+      test: [{
+        name: 'Magical Ingredients Inc.',
+        shoppingLists: [{
+          name: 'Birthday Party',
+        }],
+      }],
+    };
+    resp.body.data.should.deep.equal(expectedData);
   });
 });


### PR DESCRIPTION
There are several improvements included in this change to further reduce CPU time spent on synthetic and datafileSchema resolver. Continue from https://github.com/app-sre/qontract-server/pull/172.

* Add a new field `datafilesBySchema` to `Bundle` as a fast lookup `datafiles` by `schema`, this is used in precompute synthetic field resolver and runtime check for datafileSchema fields.
* Add a new field `syntheticBackRefTrie` to `Bundle` to provide fast lookup `datafiles` by `(schema, subAttrs, path)`.
* Add a new task to debug typescript directly: `make debug`

Step by step CPU time on my local machine for nested subAttr field - query saasfiles and their selfServiceRoles via the synthetic relation:

1. old implementation: 749-811ms
2. [Precompute datafilesBySchema for resolveSyntheticField](https://github.com/app-sre/qontract-server/commit/7c1d8e134d7d7e4d30f4dc4003b985b8e645867a): 337-382ms
3. [Use Trie to speed up synthetic resolver](https://github.com/app-sre/qontract-server/commit/1059681b04b71c77619ebdd07f2ac208c214d2a9): 256-314ms
4. [Restructure trie to inverted index to further boost synthetic resolver](https://github.com/app-sre/qontract-server/commit/39f1e1b13da28deff2e67aa87b8c6e85935cd2a3): 176-210ms

https://issues.redhat.com/browse/APPSRE-7165

Signed-off-by: Di Wang <dwan@redhat.com>