### PR TITLE
Add NODE_OPTIONS env to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ RUN npm install -g yarn && npm cache clean --force
 COPY --from=prod $HOME $HOME
 COPY --from=dev ${HOME}/dist ./dist
 EXPOSE 4000
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 CMD ["yarn", "run", "server"]

--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -187,6 +187,8 @@ objects:
                 secretKeyRef:
                     key: aws.secret.access.key
                     name: app-interface
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=${{MAX_OLD_SPACE_SIZE}}"
           ports:
           - name: app-interface
             containerPort: 4000
@@ -254,6 +256,8 @@ parameters:
   value: quay.io/app-sre/s3-reload
 - name: IMAGE_RELOADER_TAG
   value: 0bc8c97
+- name: MAX_OLD_SPACE_SIZE
+  value: 400
 
 # container 'app-interface' resources
 - name: APP_INTERFACE_RESOURCES


### PR DESCRIPTION
* set default `NODE_OPTIONS` to `"--max-old-space-size=4096"` in Dockerfile
* set default `MAX_OLD_SPACE_SIZE` to `400` according to default memory limit `512Mi` in openshift template