### PR TITLE
Template change number to string

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -257,7 +257,7 @@ parameters:
 - name: IMAGE_RELOADER_TAG
   value: 0bc8c97
 - name: MAX_OLD_SPACE_SIZE
-  value: 400
+  value: "400"
 
 # container 'app-interface' resources
 - name: APP_INTERFACE_RESOURCES


### PR DESCRIPTION
Fix to #193 

When deploying, getting the following error:

`[2023-03-02 06:04:58] [ERROR] [saasherder.py:_process_template:998] - [saas-qontract-server-int/qontract-server] https://github.com/app-sre/qontract-server/blob/master/openshift/app-interface.yaml: error processing template: [None]: error: failed to read input object (not a Template?): unable to decode "STDIN": json: cannot unmarshal number into Go struct field Parameter.parameters.value of type string`

Believe that is because that `400` is interpreted as a number rather than a string