### PR TITLE
Change param to string value for template

### DIFF
--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -188,7 +188,7 @@ objects:
                     key: aws.secret.access.key
                     name: app-interface
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=${{MAX_OLD_SPACE_SIZE}}"
+              value: "--max-old-space-size=${MAX_OLD_SPACE_SIZE}"
           ports:
           - name: app-interface
             containerPort: 4000


### PR DESCRIPTION
Following https://docs.openshift.com/container-platform/4.12/openshift_images/using-templates.html#templates-writing-parameters_using-templates, switch to just a string param as:

> When using the ${{PARAMETER_NAME}} syntax only a single parameter reference is allowed and leading and trailing characters are not permitted. The resulting value is unquoted unless, after substitution is performed, the result is not a valid JSON object. If the result is not a valid JSON value, the resulting value is quoted and treated as a standard string.
