### PR TITLE
Fix for errors when retrieving a schema without a data file associated

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -82,18 +82,19 @@ const resolveSyntheticField = (bundle: db.Bundle,
 
 const resolveDatafileSchemaField = (bundle: db.Bundle,
                                     schema: string,
-                                    args: any): (Datafile[] | undefined) => {
+                                    args: any): (Datafile[] | []) => {
 
   // that get is not guaranteed to return a value so if it doesn't, we will just returned
   // undefined from the function rather than cause an error
-  const datafile = bundle.datafilesBySchema.get(schema);
+  const datafiles = bundle.datafilesBySchema.get(schema);
 
-  if (datafile) {
-    return datafile.filter((df: Datafile) => Object.entries(args)
+  if (datafiles) {
+    return datafiles
+      .filter((df: Datafile) => Object.entries(args)
       .every(([key, value]) => key in df && value === df[key]))
       .valueSeq()
       .toArray();
-  }  return undefined;
+  }  return [];
 };
 
 // default resolver
@@ -223,7 +224,7 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
             app.get('bundles')[bundleSha],
             fieldInfo.datafileSchema,
             args,
-        ) || [];
+        );
       } else if (fieldInfo.synthetic) {
         // synthetic
         fieldDef['resolve'] = (root: any) => resolveSyntheticField(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -82,13 +82,19 @@ const resolveSyntheticField = (bundle: db.Bundle,
 
 const resolveDatafileSchemaField = (bundle: db.Bundle,
                                     schema: string,
-                                    args: any): Datafile[] =>
-    bundle.datafilesBySchema
-        .get(schema)
-        .filter((df: Datafile) => Object.entries(args)
-            .every(([key, value]) => key in df && value === df[key]))
-        .valueSeq()
-        .toArray();
+                                    args: any): (Datafile[] | undefined) => {
+
+  // that get is not guaranteed to return a value so if it doesn't, we will just returned
+  // undefined from the function rather than cause an error
+  const datafile = bundle.datafilesBySchema.get(schema);
+
+  if (datafile) {
+    return datafile.filter((df: Datafile) => Object.entries(args)
+      .every(([key, value]) => key in df && value === df[key]))
+      .valueSeq()
+      .toArray();
+  }  return undefined;
+};
 
 // default resolver
 export const defaultResolver = (app: express.Express, bundleSha: string) =>
@@ -217,7 +223,7 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
             app.get('bundles')[bundleSha],
             fieldInfo.datafileSchema,
             args,
-        );
+        ) || [];
       } else if (fieldInfo.synthetic) {
         // synthetic
         fieldDef['resolve'] = (root: any) => resolveSyntheticField(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -94,7 +94,9 @@ const resolveDatafileSchemaField = (bundle: db.Bundle,
       .every(([key, value]) => key in df && value === df[key]))
       .valueSeq()
       .toArray();
-  }  return [];
+  }
+  return [];
+
 };
 
 // default resolver

--- a/test/datafileobject/data.json
+++ b/test/datafileobject/data.json
@@ -116,6 +116,22 @@
                 ]
             },
             {
+                "name": "RecipeCollection_v2",
+                "fields": [
+                    {
+                        "isRequired": true,
+                        "type": "string",
+                        "name": "name"
+                    },
+                    {
+                        "type": "DatafileObject_v1",
+                        "isInterface": true,
+                        "name": "recipes",
+                        "isList": true
+                    }
+                ]
+            },
+            {
                 "fields": [
                     {
                         "type": "RecipeCollection_v1",
@@ -134,6 +150,12 @@
                         "name": "beerrecipe_v1",
                         "isList": true,
                         "datafileSchema": "/beerrecipe-1.yml"
+                    },
+                    {
+                        "type": "RecipeCollection_v2",
+                        "name": "recipecollection_v2",
+                        "isList": true,
+                        "datafileSchema": "/recipecollection-2.yml"
                     }
                 ],
                 "name": "Query"

--- a/test/datafileobject/datafileobject.test.ts
+++ b/test/datafileobject/datafileobject.test.ts
@@ -51,4 +51,25 @@ describe('pathobject', async() => {
     resp.body.data.test[0].recipes[1].schema.should.equal('/beerrecipe-1.yml');
     return resp.body.data.test[0].recipes[1].brewery.should.equal('Equestrias Finest');
   });
+
+  it('resolves empty datafileobject', async() => {
+    const query = `
+      {
+        test: recipecollection_v2 {
+          name
+          recipes {
+            path
+            schema
+          }
+        }
+      }
+    `;
+
+    const resp = await chai.request(srv)
+                          .post('/graphql')
+                          .set('content-type', 'application/json')
+                          .send({ query });
+    resp.should.have.status(200);
+    return resp.body.data.test.should.be.empty;
+  });
 });


### PR DESCRIPTION
In #190 , some behaviors with schemas were changed. This resulted in a new error when queries were made against schemas with no data associated with them in App Interface. We would receive errors like so:

```
`error` returned with GraphQL response {'message': "Cannot read properties of undefined (reading 'filter')", 'locations': [{'line': 2, 'column': 3}], 'path': ['external_users'], 'extensions': {'code': 'INTERNAL_SERVER_ERROR'}}
`error` returned with GraphQL response {'message': "Cannot read properties of undefined (reading 'filter')", 'locations': [{'line': 9, 'column': 3}], 'path': ['zones'], 'extensions': {'code': 'INTERNAL_SERVER_ERROR'}}
`error` returned with GraphQL response {'message': "Cannot read properties of undefined (reading 'filter')", 'locations': [{'line': 2, 'column': 3}], 'path': ['sql_queries'], 'extensions': {'code': 'INTERNAL_SERVER_ERROR'}}
```

In each of these cases, we had no actual data associated with any of these schemas in our instance. This change adds a check for these cases and returns a default blank array to match the behavior before that prior PR. Resulting in:

![Screenshot_20230307_104515](https://user-images.githubusercontent.com/4098927/223478836-8edbf79b-f8cf-4bf4-a4b1-f89c37223694.png)

More context is available in this slack thread: https://redhat-internal.slack.com/archives/GGC2A0MS8/p1678121084668049