### PR TITLE
Ignore null as args value for searchable fields

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -82,21 +82,21 @@ const resolveSyntheticField = (bundle: db.Bundle,
 
 const resolveDatafileSchemaField = (bundle: db.Bundle,
                                     schema: string,
-                                    args: any): (Datafile[] | []) => {
-
-  // that get is not guaranteed to return a value so if it doesn't, we will just returned
+                                    args: any): Datafile[] => {
+  // that get is not guaranteed to return a value so if it doesn't, we will just return
   // undefined from the function rather than cause an error
   const datafiles = bundle.datafilesBySchema.get(schema);
 
-  if (datafiles) {
-    return datafiles
-      .filter((df: Datafile) => Object.entries(args)
-      .every(([key, value]) => key in df && value === df[key]))
+  if (!datafiles) return [];
+
+  const filters = Object.entries(args)
+    .filter(([_, value]) => value != null);
+
+  return datafiles
+      .filter((df: Datafile) =>
+        filters.every(([key, value]) => key in df && value === df[key]))
       .valueSeq()
       .toArray();
-  }
-  return [];
-
 };
 
 // default resolver

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -198,7 +198,24 @@ describe('server', async () => {
                             .set('content-type', 'application/json')
                             .send({ query });
     responseIsNotAnError(response);
+    response.body.data.roles_v1.length.should.equal(1);
     return response.body.data.roles_v1[0].path.should.equal('/role-B.yml');
+  });
+
+  it('can search by name (isSearchable) with null to ignore filter', async () => {
+    const query = `{
+      roles_v1(name: null) {
+        path
+        name
+      }
+    }`;
+
+    const response = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    responseIsNotAnError(response);
+    return response.body.data.roles_v1.length.should.equal(2);
   });
 
   it('cannot search by name (NOT isSearchable)', async () => {


### PR DESCRIPTION
`null` was being used to do value match on datafile fields, this makes typed query hard because it requires a template to render conditional filter. For example [AWS_ACCOUNTS_QUERY](https://github.com/app-sre/qontract-reconcile/blob/344a8026c3cca7ad00f36f3846cfff90b7d61ba8/reconcile/queries.py#L458-L467).

This change allows `null` to be ignored so a single `gql` file with args always populated will be enough.