### PR TITLE
Replace node-forge with built-in crypto module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "graphql": "^14.0.0",
     "immutable": "^4.0.0-rc.12",
     "jsonpointer": "^4.0.1",
-    "node-forge": "^0.10.0",
     "prom-client": "^12.0.0",
     "winston": "^3.3.3"
   },
@@ -35,7 +34,6 @@
     "@types/express": "^4.16.0",
     "@types/graphql": "^14.0.5",
     "@types/mocha": "^7.0.2",
-    "@types/node-forge": "^0.9.3",
     "@types/webpack": "^4.4.22",
     "chai": "^4.2.0",
     "chai-http": "^4.2.1",

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs';
 import * as util from 'util';
+import { createHash } from 'crypto';
 
 import * as aws from 'aws-sdk';
 import * as im from 'immutable';
-import { md as forgeMd } from 'node-forge';
 import { logger } from './logger';
 import { buildSyntheticBackRefTrie, SyntheticBackRefTrie } from './syntheticBackRefTrie';
 import { Datafile, GraphQLSchemaType } from './types';
@@ -122,7 +122,7 @@ const parseResourcefiles = (jsonData: object) : im.Map<string, Resourcefile> => 
 };
 
 const hashDatafile = (contents: string) => {
-  return forgeMd.sha256.create().update(contents).digest().toHex();
+  return createHash('sha256').update(contents).digest('hex');
 };
 
 const bundleFromS3 = async(accessKeyId: string, secretAccessKey: string, region: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,13 +327,6 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node-forge@^0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-0.9.3.tgz#5f8299a3f2b069a7e165c807bef6b17464f8b8ad"
-  integrity sha512-2ARlg50tba1Ps3Jg/D416LEWo9TxVACfuZLNy8GvLiggndLxxfUBz8OyeZZsE9JIF6r8AOJrcaKS3O/5NVhQlA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "14.11.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
@@ -3243,11 +3236,6 @@ node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-libs-browser@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
Use built-in [crypto.createHash](https://nodejs.org/docs/latest-v16.x/api/crypto.html#cryptocreatehashalgorithm-options) to do sha256 calculation, one less dependency.