### PR TITLE
Remove immutable.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "express": "^4.16.4",
     "express-prom-bundle": "^6.0.0",
     "graphql": "^14.0.0",
-    "immutable": "^4.0.0-rc.12",
     "jsonpointer": "^4.0.1",
     "prom-client": "^12.0.0",
     "winston": "^3.3.3"

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -103,9 +103,7 @@ const resolveDatafileSchemaField = (
 
   return datafiles
     .filter((df: Datafile) => filters
-      .every(([key, value]) => key in df && value === df[key]))
-    .valueSeq()
-    .toArray();
+      .every(([key, value]) => key in df && value === df[key]));
 };
 
 // default resolver

--- a/src/syntheticBackRefTrie.ts
+++ b/src/syntheticBackRefTrie.ts
@@ -1,5 +1,4 @@
 // eslint-disable-next-line max-classes-per-file
-import { Collection, Seq } from 'immutable';
 import { Datafile, GraphQLSchemaType } from './types';
 
 class TrieNode {
@@ -114,17 +113,16 @@ const getSyntheticFieldSubAttrsBySchema = (
 };
 
 export const buildSyntheticBackRefTrie = (
-  datafilesBySchema: Seq.Keyed<string, Collection<string, Datafile>>,
+  datafilesBySchema: Map<string, Array<Datafile>>,
   schema: GraphQLSchemaType | any[],
 ): SyntheticBackRefTrie => {
   const syntheticBackRefTrie = new SyntheticBackRefTrie();
   const syntheticFieldSubAttrsBySchema = getSyntheticFieldSubAttrsBySchema(schema);
   syntheticFieldSubAttrsBySchema.forEach((subAttrs: Set<string>, s: string) => {
     (datafilesBySchema.get(s) || []).forEach((df: Datafile) => {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const subAttr of subAttrs) {
+      subAttrs.forEach((subAttr: string) => {
         syntheticBackRefTrie.insert(s, subAttr.split('.'), df);
-      }
+      });
     });
   });
   return syntheticBackRefTrie;

--- a/test/datafileobject/datafileobject.test.ts
+++ b/test/datafileobject/datafileobject.test.ts
@@ -10,6 +10,7 @@ import * as server from '../../src/server';
 import * as db from '../../src/db';
 
 chai.use(chaiHttp);
+chai.should();
 
 describe('pathobject', async () => {
   let srv: http.Server;

--- a/test/diff/diff.test.ts
+++ b/test/diff/diff.test.ts
@@ -10,6 +10,7 @@ import * as server from '../../src/server';
 import * as db from '../../src/db';
 
 chai.use(chaiHttp);
+chai.should();
 
 const diskBundles = 'fs://test/diff/old.data.json,fs://test/diff/new.data.json';
 const oldSha = 'bf56095bf2ada36a6b2deca9cb9b6616d536b5c9ce230f0905296165d221a66b';

--- a/test/multishas/multishas.test.ts
+++ b/test/multishas/multishas.test.ts
@@ -10,7 +10,6 @@ import * as server from '../../src/server';
 import * as db from '../../src/db';
 
 chai.use(chaiHttp);
-
 const should = chai.should();
 
 const gql = (srv: http.Server, query: string, sha?: string) => {

--- a/test/resourceref/resourceref.test.ts
+++ b/test/resourceref/resourceref.test.ts
@@ -10,6 +10,7 @@ import * as server from '../../src/server';
 import * as db from '../../src/db';
 
 chai.use(chaiHttp);
+chai.should();
 
 describe('clusters', async () => {
   let srv: http.Server;

--- a/test/schemas/schemas.test.ts
+++ b/test/schemas/schemas.test.ts
@@ -10,6 +10,7 @@ import * as server from '../../src/server';
 import * as db from '../../src/db';
 
 chai.use(chaiHttp);
+chai.should();
 
 ['test/schemas/schemas.data.json', 'test/schemas/schemas.data.with.graphql.schema.header.json']
   .forEach((DATAFILES_FILE) => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -11,6 +11,7 @@ import * as server from '../src/server';
 import * as db from '../src/db';
 
 chai.use(chaiHttp);
+chai.should();
 
 const { expect } = chai;
 

--- a/test/synthetic/synthetic.test.ts
+++ b/test/synthetic/synthetic.test.ts
@@ -10,6 +10,7 @@ import * as server from '../../src/server';
 import * as db from '../../src/db';
 
 chai.use(chaiHttp);
+chai.should();
 
 describe('synthetic', async () => {
   let srv: http.Server;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,11 +2120,6 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-immutable@^4.0.0-rc.12:
-  version "4.0.0-rc.12"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
-  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
-
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"


### PR DESCRIPTION
Current `"immutable": "^4.0.0-rc.12"` is outdated, since qontract-server is a read-only system, removing this package and replace it with built-in types, like `Map`, `Set`, `Array`.

Heap memory dropped about 20 MB after deletion, no obvious change in query performance (~10ms faster).

[APPSRE-7475](https://issues.redhat.com/browse/APPSRE-7475)