### PR TITLE
Fix dotenv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,23 @@ make bundle APP_INTERFACE_PATH=/home/myuser/app-interface/
 
 ### Running the Qontract GraphQL server
 
+Create `.env` file from example:
+
+```shell
+cp .env.example .env
+```
+
+Customize the `.env` file as needed, for example:
+
+```
+LOAD_METHOD=fs
+DATAFILES_FILE=./bundle/bundle.json
+```
+
 To run an instance of the qontract GraphQL console:
 
 ```sh
-LOAD_METHOD=fs DATAFILES_FILE=your_test_datafile yarn run server
+yarn run server
 ```
 
 Specific instructions for CentOS 7:

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { ApolloServer } from 'apollo-server-express';
 import * as express from 'express';
 


### PR DESCRIPTION
`dotenv` package is installed but not used correctly, missing `import`. This change fixed usage and updated README.

Now `npx depcheck` show `No depcheck issue`.

[APPSRE-7475](https://issues.redhat.com/browse/APPSRE-7475)