### PR TITLE
list based filtering on searchable fields

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -59,11 +59,7 @@ const truePredicate = (_: any): boolean => true; // eslint-disable-line no-unuse
 const fieldEqPredicateBuilder = (field: string, ignoreNull: boolean): FilterPredicateBuilder => (
   (value: any): FilterPredicate => {
     if (value == null && ignoreNull) return truePredicate;
-    return (source: any): boolean => {
-      const fieldExistsWithValue = field in source && source[field] === value;
-      const fieldDoesNotExistAndValueIsNull = !(field in source) && value == null;
-      return fieldExistsWithValue || fieldDoesNotExistAndValueIsNull;
-    };
+    return (source: any): boolean => (source[field] ?? null) === value;
   }
 );
 

--- a/test/filter/data.json
+++ b/test/filter/data.json
@@ -18,6 +18,18 @@
       "/resource-d.yml": {
         "$schema": "/resource-1.yml",
         "name": "resource D"
+      },
+      "/resource-e.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource E",
+        "optional_field": "E",
+        "list_field": ["A", "B", "C"]
+      },
+      "/resource-f.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource F",
+        "optional_field": "F",
+        "list_field": ["C", "D", "E"]
       }
     },
     "graphql": [
@@ -43,6 +55,12 @@
           {
             "type": "string",
             "name": "optional_field",
+            "isRequired": false
+          },
+          {
+            "type": "string",
+            "name": "list_field",
+            "isList": true,
             "isRequired": false
           }
         ]

--- a/test/filter/data.json
+++ b/test/filter/data.json
@@ -2,15 +2,22 @@
     "data": {
       "/resource-a.yml": {
         "$schema": "/resource-1.yml",
-        "name": "resource A"
+        "name": "resource A",
+        "optional_field": "A"
       },
       "/resource-b.yml": {
         "$schema": "/resource-1.yml",
-        "name": "resource B"
+        "name": "resource B",
+        "optional_field": "B"
       },
       "/resource-c.yml": {
         "$schema": "/resource-1.yml",
-        "name": "resource C"
+        "name": "resource C",
+        "optional_field": "C"
+      },
+      "/resource-d.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource D"
       }
     },
     "graphql": [
@@ -25,13 +32,18 @@
           {
             "isRequired": true,
             "type": "string",
+            "name": "path"
+          },
+          {
+            "type": "string",
             "name": "name",
+            "isRequired": true,
             "isSearchable": true
           },
           {
-            "isRequired": true,
             "type": "string",
-            "name": "path"
+            "name": "optional_field",
+            "isRequired": false
           }
         ]
       },

--- a/test/filter/data.json
+++ b/test/filter/data.json
@@ -1,0 +1,51 @@
+{
+    "data": {
+      "/resource-a.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource A"
+      },
+      "/resource-b.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource B"
+      },
+      "/resource-c.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource C"
+      }
+    },
+    "graphql": [
+      {
+        "name": "Resource_v1",
+        "fields": [
+          {
+            "isRequired": true,
+            "type": "string",
+            "name": "schema"
+          },
+          {
+            "isRequired": true,
+            "type": "string",
+            "name": "name",
+            "isSearchable": true
+          },
+          {
+            "isRequired": true,
+            "type": "string",
+            "name": "path"
+          }
+        ]
+      },
+      {
+        "fields": [
+            {
+                "type": "Resource_v1",
+                "name": "resources_v1",
+                "isList": true,
+                "datafileSchema": "/resource-1.yml"
+            }
+        ],
+        "name": "Query"
+    }
+    ],
+    "resources": {}
+}

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -1,0 +1,57 @@
+import * as http from 'http';
+
+import * as chai from 'chai';
+
+// Chai is bad with types. See:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19480
+import chaiHttp = require('chai-http');
+
+import * as server from '../../src/server';
+import * as db from '../../src/db';
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('pathobject', async () => {
+  let srv: http.Server;
+  before(async () => {
+    process.env.LOAD_METHOD = 'fs';
+    process.env.DATAFILES_FILE = 'test/filter/data.json';
+    const app = await server.appFromBundle(db.getInitialBundles());
+    srv = app.listen({ port: 4000 });
+  });
+
+  it('filter by searchable field', async () => {
+    const query = `
+      {
+        test: resources_v1(name: "resource A") {
+          path
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test[0].name.should.equal('resource A');
+  });
+
+  it('filter by searchable field value list', async () => {
+    const query = `
+      {
+        test: resources_v1(name__in__: ["resource A", "resource B"]) {
+          path
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    new Set(resp.body.data.test.map((r: { name: string; }) => r.name)).should.deep.equal(new Set(['resource A', 'resource B']));
+  });
+});

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -37,6 +37,22 @@ describe('pathobject', async () => {
     resp.body.data.test[0].name.should.equal('resource A');
   });
 
+  it('filter by searchable field with null value', async () => {
+    const query = `
+      {
+        test: resources_v1(name: null) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.equal(4);
+  });
+
   it('filter with filter object and single value', async () => {
     const query = `
       {
@@ -53,7 +69,7 @@ describe('pathobject', async () => {
     resp.body.data.test[0].name.should.equal('resource A');
   });
 
-  it('filter with filter object and list value', async () => {
+  it('filter object with list field value', async () => {
     const query = `
       {
         test: resources_v1(filter: {name: ["resource A", "resource B"]}) {
@@ -69,7 +85,7 @@ describe('pathobject', async () => {
     new Set(resp.body.data.test.map((r: { name: string; }) => r.name)).should.deep.equal(new Set(['resource A', 'resource B']));
   });
 
-  it('filter with filter object and unknown field', async () => {
+  it('filter object with unknown field', async () => {
     const query = `
       {
         test: resources_v1(filter: {unknown_field: "value"}) {
@@ -83,5 +99,22 @@ describe('pathobject', async () => {
       .send({ query });
     resp.should.have.status(200);
     resp.body.errors.length.should.equal(1);
+  });
+
+  it('filter object with null field value', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {optional_field: null}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.equal(1);
+    resp.body.data.test[0].name.should.equal('resource D');
   });
 });

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -25,7 +25,6 @@ describe('pathobject', async () => {
     const query = `
       {
         test: resources_v1(name: "resource A") {
-          path
           name
         }
       }
@@ -42,7 +41,6 @@ describe('pathobject', async () => {
     const query = `
       {
         test: resources_v1(filter: {name: "resource A"}) {
-          path
           name
         }
       }
@@ -59,7 +57,6 @@ describe('pathobject', async () => {
     const query = `
       {
         test: resources_v1(filter: {name: ["resource A", "resource B"]}) {
-          path
           name
         }
       }
@@ -70,5 +67,21 @@ describe('pathobject', async () => {
       .send({ query });
     resp.should.have.status(200);
     new Set(resp.body.data.test.map((r: { name: string; }) => r.name)).should.deep.equal(new Set(['resource A', 'resource B']));
+  });
+
+  it('filter with filter object and unknown field', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {unknown_field: "value"}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.errors.length.should.equal(1);
   });
 });

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -38,10 +38,27 @@ describe('pathobject', async () => {
     resp.body.data.test[0].name.should.equal('resource A');
   });
 
-  it('filter by searchable field value list', async () => {
+  it('filter with filter object and single value', async () => {
     const query = `
       {
-        test: resources_v1(name__in__: ["resource A", "resource B"]) {
+        test: resources_v1(filter: {name: "resource A"}) {
+          path
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test[0].name.should.equal('resource A');
+  });
+
+  it('filter with filter object and list value', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {name: ["resource A", "resource B"]}) {
           path
           name
         }


### PR DESCRIPTION
searchable fields can be used for filtering but only one value can be given at a time.

this PR adds support for basic filter object support. 

this exmple shows an `in` condition that allows us to filter objects based on a list of identifiers.

```gql
query SelfServiceRolesQuery {
  roles: roles_v1(filter: {
    name: {in: ["my-role", "my-other-role"]}
  }) {
    name
  }
}
```

additionally the filter object can also be used for field and array equality

```gql
query SelfServiceRolesQuery {
  roles: roles_v1(filter: {
    name: "a name",
    list_field: ["A", "B"]
  }) {
    name
  }
}
```

`null` handling is different from the existing searchable field behaviour. the following example expects `some_optional_field` to be really null instead of ignoring the filter.

```gql
query SelfServiceRolesQuery {
  roles: roles_v1(filter: {
    some_optional_field: null
  }) {
    ...
  }
}
```

https://issues.redhat.com/browse/APPSRE-8502