### PR TITLE
filtering for nested data

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Filtering is also supported on nested structures of a resource.
 "filter": {
     "nested_resources": {
         "filter": {
-            "nested_field": "value"
+            "nested_field": "nested_value"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -192,3 +192,57 @@ projects lint script:
 ```sh
 yarn run lint
 ```
+
+## GQL query filtering
+
+While GQL does not define how filtering should work, it provides room for arguments to passed into queries. `qontract-server` offers a generic `filter` argument, that can be used to filter the resultset of a query.
+
+```gql
+query MyQuery($filter: JSON) {
+    clusters: clusters_v1(filter: $filter) {
+        ...
+    }
+}
+```
+
+The filter argument is a JSON document that can have the following content.
+
+### Field equality predicate
+
+To filter on an fields value, use the following filter object syntax
+
+```json
+"filter": {
+    "my_field": "my_value"
+}
+```
+
+This way only resources with such a field and value are returned by the query.
+
+### List contains predicate
+
+Field values can be also compared towards a list of acceptable values.
+
+```json
+"filter": {
+    "my_field": {
+        "in": ["a", "b", "c"]
+    }
+}
+```
+
+This way only resources are returned where the respective field is a or b or c.
+
+### Nested predicates
+
+Filtering is also supported on nested structures of a resource.
+
+```json
+"filter": {
+    "nested_resources": {
+        "filter": {
+            "nested_field": "value"
+        }
+    }
+}
+```

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -144,16 +144,6 @@ const resolveValue = (
   return val;
 };
 
-const extractListOfValues = (
-  app: express.Express,
-  bundleSha: string,
-  field: string,
-  source: any,
-): any[] => {
-  const sources = Array.isArray(source) ? source : [source];
-  return sources.map((e: any) => resolveValue(app, bundleSha, e, {}, { fieldName: field }));
-};
-
 const getFilters = (
   app: express.Express,
   bundleSha: string,
@@ -258,10 +248,6 @@ const filterObjectPredicateBuilder = (
       switch (true) {
         case fieldType.isList && Array.isArray(value):
           return arrayEqPredicate.bind(null, field, value);
-        case Array.isArray(value):
-          return (source: any): boolean => (
-            arrayEqPredicate('values', value, { values: extractListOfValues(app, bundleSha, field, source) })
-          );
         case isConditionsObject(value):
           return conditionsObjectPredicateDeconstructor.bind(
             null,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -88,7 +88,7 @@ const containsPredicate = (field: string, value: Set<string>, source: any): bool
   field in source && value.has(source[field])
 );
 
-const isNonEmptyArray = (obj: any) => obj.constructor === Array && obj.length > 0;
+const isNonEmptyArray = (obj: any) => Array.isArray(obj) && obj.length > 0;
 
 const resolveValue = (
   app: express.Express,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -189,14 +189,12 @@ const conditionsObjectPredicateDeconstructor = (
   bundleSha: string,
   source: any,
 ): boolean => {
-  if (Array.isArray(source)) {
-    return source.every(
-      (e: any) => (
-        conditionsObjectPredicate(field, value, fieldGqlType, app, bundleSha, e)
-      ),
-    );
-  }
-  return conditionsObjectPredicate(field, value, fieldGqlType, app, bundleSha, source);
+  const sources = Array.isArray(source) ? source : [source];
+  return sources.every(
+    (e: any) => (
+      conditionsObjectPredicate(field, value, fieldGqlType, app, bundleSha, e)
+    ),
+  );
 };
 
 const getGraphGQLTypeFields = (

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -240,21 +240,22 @@ const filterObjectPredicateBuilder = (
     if (typeof filterObject !== 'object') return falsePredicate;
     const filters: FilterPredicate[] = Object.entries(filterObject).map(([field, value]) => {
       const fieldType = supportedFieldsInSchema.get(field);
+      if (fieldType == null) {
+        throw new GraphQLError(
+          `Field "${field}" does not exist on type "${gqlType.name}"`,
+          undefined,
+          null,
+          null,
+          null,
+          null,
+          {
+            code: 'BAD_FILTER_FIELD',
+            gqlType: gqlType.name,
+          },
+        );
+      }
       const fieldGglType = getGqlType(app, bundleSha, fieldType.type);
       switch (true) {
-        case !supportedFieldsInSchema.has(field):
-          throw new GraphQLError(
-            `Field ${field} on ${gqlType.name} can not be used for filtering (yet)`,
-            undefined,
-            null,
-            null,
-            null,
-            null,
-            {
-              code: 'BAD_FILTER_FIELD',
-              gqlType: gqlType.name,
-            },
-          );
         case fieldType.isList && Array.isArray(value):
           return arrayEqPredicate.bind(null, field, value);
         case Array.isArray(value):

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -94,7 +94,6 @@ const resolveValue = (
   app: express.Express,
   bundleSha: string,
   root: any,
-  args: any,
   context: any,
   info: any,
 ): any => {
@@ -152,7 +151,7 @@ const extractListOfValues = (
   source: any,
 ): any[] => {
   const sources = Array.isArray(source) ? source : [source];
-  return sources.map((e: any) => resolveValue(app, bundleSha, e, null, {}, { fieldName: field }));
+  return sources.map((e: any) => resolveValue(app, bundleSha, e, {}, { fieldName: field }));
 };
 
 const getFilters = (
@@ -183,7 +182,7 @@ const conditionsObjectPredicate = (
   }
   if (Object.prototype.hasOwnProperty.call(value, 'filter')) {
     const filterSpecs = getFilters(app, bundleSha, fieldGqlType.name);
-    const fieldValue = resolveValue(app, bundleSha, source, null, {}, { fieldName: field });
+    const fieldValue = resolveValue(app, bundleSha, source, {}, { fieldName: field });
     if (fieldValue == null) return false;
     return filterSpecs.filter.predicateBuilder(value.filter)(fieldValue);
   }
@@ -379,7 +378,7 @@ export const defaultResolver = (
   app: express.Express,
   bundleSha: string,
 ) => (root: any, args: any, context: any, info: any) => {
-  const resolved = resolveValue(app, bundleSha, root, args, context, info);
+  const resolved = resolveValue(app, bundleSha, root, context, info);
   if (Object.keys(args).length !== 0) {
     const filterSpecs = getFilters(app, bundleSha, getInnerGqlType(info.returnType));
     const filterArgs = Object.entries(args)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -29,6 +29,12 @@ const addObjectType = (app: express.Express, bundleSha: string, name: string, ob
 
 const getObjectType = (app: express.Express, bundleSha: string, name: string) => app.get('objectTypes')[bundleSha][name];
 
+const getInterfaceType = (app: express.Express, bundleSha: string, name: string) => app.get('objectInterfaces')[bundleSha][name];
+
+const getGqlType = (app: express.Express, bundleSha: string, name: string) => (
+  app.get('bundles')[bundleSha].schema.confs.find((t: any) => t.name === name)
+);
+
 const jsonType = new GraphQLScalarType({
   name: 'JSON',
   serialize: JSON.stringify,
@@ -82,156 +88,19 @@ const containsPredicate = (field: string, value: Set<string>, source: any): bool
   field in source && value.has(source[field])
 );
 
-const conditionsObjectPredicate = (field: string, value: any, source: any): boolean => {
-  switch (true) {
-    case 'in' in value:
-      return containsPredicate(field, new Set(value.in as Array<string>), source);
-    default:
-      throw new GraphQLError(
-        `Condition object ${value} unsupported`,
-      );
-  }
-};
-
-const filterObjectPredicateBuilder = (gqlType: any): FilterPredicateBuilder => (
-  (filterObject: any): FilterPredicate => {
-    const supportedFieldsInSchema = new Map<string, any>(
-      gqlType.fields.filter(
-        (f: any) => ['string', 'int', 'boolean'].includes(f.type),
-      ).map(
-        (f: any) => [f.name, f],
-      ),
-    );
-    if (typeof filterObject !== 'object') return falsePredicate;
-    const filters: FilterPredicate[] = Object.entries(filterObject).map(([field, value]) => {
-      switch (true) {
-        case !supportedFieldsInSchema.has(field):
-          throw new GraphQLError(
-            `Field ${field} on ${gqlType.name} can not be used for filtering (yet)`,
-            undefined,
-            null,
-            null,
-            null,
-            null,
-            {
-              code: 'BAD_FILTER_FIELD',
-              gqlType: gqlType.name,
-            },
-          );
-        case supportedFieldsInSchema.get(field).isList && Array.isArray(value):
-          return arrayEqPredicate.bind(null, field, value);
-        case typeof value === 'object' && value !== null:
-          return conditionsObjectPredicate.bind(null, field, value);
-        default:
-          return fieldEqPredicate.bind(null, field, value);
-      }
-    });
-    return (source: any): boolean => filters.every((f) => f(source));
-  }
-);
-
-const registerFilterArgs = (
-  app: express.Express,
-  bundleSha: string,
-  gqlType: any,
-  fields: string[],
-) => {
-  if (typeof (app.get('searchableFields')[bundleSha]) === 'undefined') {
-    app.get('searchableFields')[bundleSha] = {}; // eslint-disable-line no-param-reassign
-  }
-
-  const filters: FilterDict = {};
-
-  // searchable fields + path
-  [...fields, 'path'].forEach((field) => {
-    filters[field] = new Filter(
-      fieldEqPredicateIgnoreNullBuilder(field),
-      GraphQLString,
-    );
-  });
-
-  // generic filter object
-  filters.filter = new Filter(
-    filterObjectPredicateBuilder(gqlType),
-    jsonType,
-  );
-
-  app.get('searchableFields')[bundleSha][gqlType.name] = filters; // eslint-disable-line no-param-reassign
-};
-
-const getFilters = (
-  app: express.Express,
-  bundleSha: string,
-  name: string,
-): FilterDict => app.get('searchableFields')[bundleSha][name];
-
-// interface types helpers
-const addInterfaceType = (app: express.Express, bundleSha: string, name: string, obj: any) => {
-  if (typeof (app.get('objectInterfaces')[bundleSha]) === 'undefined') {
-    app.get('objectInterfaces')[bundleSha] = {}; // eslint-disable-line no-param-reassign
-  }
-  app.get('objectInterfaces')[bundleSha][name] = obj; // eslint-disable-line no-param-reassign
-};
-
-const getInterfaceType = (app: express.Express, bundleSha: string, name: string) => app.get('objectInterfaces')[bundleSha][name];
-
-// datafile types to GraphQL type
-const addDatafileSchema = (
-  app: express.Express,
-  bundleSha: string,
-  datafileSchema: string,
-  graphqlType: string,
-) => {
-  if (typeof (app.get('datafileSchemas')[bundleSha]) === 'undefined') {
-    app.get('datafileSchemas')[bundleSha] = {}; // eslint-disable-line no-param-reassign
-  }
-  app.get('datafileSchemas')[bundleSha][datafileSchema] = graphqlType; // eslint-disable-line no-param-reassign
-};
-
-const getGraphqlTypeForDatafileSchema = (
-  app: express.Express,
-  bundleSha: string,
-  datafileSchema: string,
-) => app.get('datafileSchemas')[bundleSha][datafileSchema];
-
-// helpers
 const isNonEmptyArray = (obj: any) => obj.constructor === Array && obj.length > 0;
 
-// synthetic field resolver
-const resolveSyntheticField = (
-  bundle: db.Bundle,
-  path: string,
-  schema: string,
-  subAttr: string,
-): Datafile[] => bundle.syntheticBackRefTrie.getDatafiles(schema, subAttr.split('.'), path);
-
-const resolveDatafileSchemaField = (
-  bundle: db.Bundle,
-  schema: string,
-  searchableFields: FilterDict,
-  args: any,
-): Datafile[] => {
-  // that get is not guaranteed to return a value so if it doesn't, we will just return
-  // undefined from the function rather than cause an error
-  const datafiles = bundle.datafilesBySchema.get(schema);
-
-  if (!datafiles) return [];
-
-  const filterArgs = Object.entries(args)
-    .filter(([_, value]) => value != null); // eslint-disable-line no-unused-vars
-
-  const predicates = filterArgs.map(
-    ([key, value]) => searchableFields[key].predicateBuilder(value),
-  );
-  return datafiles
-    .filter((df: Datafile) => predicates.every((predicate) => predicate(df)));
-};
-
-// default resolver
-export const defaultResolver = (
+const resolveValue = (
   app: express.Express,
   bundleSha: string,
-) => (root: any, args: any, context: any, info: any) => {
+  root: any,
+  args: any,
+  context: any,
+  info: any,
+): any => {
+  if (root == null) {
+    return null;
+  }
   // add root.$schema to the schemas extensions
   if (typeof (root.$schema) !== 'undefined' && root.$schema) {
     if ('schemas' in context) {
@@ -276,6 +145,261 @@ export const defaultResolver = (
   return val;
 };
 
+const extractListOfValues = (
+  app: express.Express,
+  bundleSha: string,
+  field: string,
+  source: any,
+): any[] => {
+  if (Array.isArray(source)) {
+    return source.map((e: any) => resolveValue(app, bundleSha, e, null, {}, { fieldName: field }));
+  }
+  return [
+    resolveValue(app, bundleSha, source, null, {}, { fieldName: field }),
+  ];
+};
+
+const getFilters = (
+  app: express.Express,
+  bundleSha: string,
+  name: string,
+): FilterDict => app.get('searchableFields')[bundleSha][name];
+
+const isConditionsObject = (
+  conditionsObject: any,
+): boolean => {
+  if (conditionsObject == null) {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(conditionsObject, 'in') || Object.prototype.hasOwnProperty.call(conditionsObject, 'filter');
+};
+
+const conditionsObjectPredicate = (
+  field: string,
+  value: any,
+  fieldGqlType: any,
+  app: express.Express,
+  bundleSha: string,
+  source: any,
+): boolean => {
+  if (Object.prototype.hasOwnProperty.call(value, 'in')) {
+    return containsPredicate(field, new Set(value.in as Array<string>), source);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'filter')) {
+    const filterSpecs = getFilters(app, bundleSha, fieldGqlType.name);
+    const fieldValue = resolveValue(app, bundleSha, source, null, {}, { fieldName: field });
+    if (fieldValue == null) return false;
+    return filterSpecs.filter.predicateBuilder(value.filter)(fieldValue);
+  }
+  throw new GraphQLError(
+    `Condition object ${value} unsupported`,
+  );
+};
+
+const conditionsObjectPredicateDeconstuctor = (
+  field: string,
+  value: any,
+  fieldGqlType: any,
+  app: express.Express,
+  bundleSha: string,
+  source: any,
+): boolean => {
+  if (Array.isArray(source)) {
+    return source.every(
+      (e: any) => (
+        conditionsObjectPredicate(field, value, fieldGqlType, app, bundleSha, e)
+      ),
+    );
+  }
+  return conditionsObjectPredicate(field, value, fieldGqlType, app, bundleSha, source);
+};
+
+const getGraphGQLTypeFields = (
+  app: express.Express,
+  bundleSha: string,
+  gqlTypeName: any,
+): any => {
+  const gqlType = getGqlType(app, bundleSha, gqlTypeName);
+  let fieldsMap = new Map<string, any>(
+    gqlType.fields.map(
+      (f: any) => [f.name, f],
+    ),
+  );
+
+  if (gqlType.isInterface && gqlType.interfaceResolve.strategy === 'fieldMap') {
+    Object.values(gqlType.interfaceResolve.fieldMap).forEach((typeName: string) => {
+      const interfaceFields = getGraphGQLTypeFields(app, bundleSha, typeName);
+      fieldsMap = new Map([...fieldsMap, ...interfaceFields]);
+    });
+  }
+  return fieldsMap;
+};
+
+const filterObjectPredicateBuilder = (
+  gqlType: any,
+  app: express.Express,
+  bundleSha: string,
+): FilterPredicateBuilder => (
+  (filterObject: any): FilterPredicate => {
+    const supportedFieldsInSchema = getGraphGQLTypeFields(app, bundleSha, gqlType.name);
+    if (typeof filterObject !== 'object') return falsePredicate;
+    const filters: FilterPredicate[] = Object.entries(filterObject).map(([field, value]) => {
+      const fieldType = supportedFieldsInSchema.get(field);
+      const fieldGglType = getGqlType(app, bundleSha, fieldType.type);
+      switch (true) {
+        case !supportedFieldsInSchema.has(field):
+          throw new GraphQLError(
+            `Field ${field} on ${gqlType.name} can not be used for filtering (yet)`,
+            undefined,
+            null,
+            null,
+            null,
+            null,
+            {
+              code: 'BAD_FILTER_FIELD',
+              gqlType: gqlType.name,
+            },
+          );
+        case fieldType.isList && Array.isArray(value):
+          return arrayEqPredicate.bind(null, field, value);
+        case Array.isArray(value):
+          return (source: any): boolean => (
+            arrayEqPredicate('values', value, { values: extractListOfValues(app, bundleSha, field, source) })
+          );
+        case isConditionsObject(value):
+          return conditionsObjectPredicateDeconstuctor.bind(
+            null,
+            field,
+            value,
+            fieldGglType,
+            app,
+            bundleSha,
+          );
+        default:
+          return fieldEqPredicate.bind(null, field, value);
+      }
+    });
+    return (source: any): boolean => filters.every((f) => f(source));
+  }
+);
+
+const registerFilterArgs = (
+  app: express.Express,
+  bundleSha: string,
+  gqlType: any,
+  fields: string[],
+) => {
+  if (typeof (app.get('searchableFields')[bundleSha]) === 'undefined') {
+    app.get('searchableFields')[bundleSha] = {}; // eslint-disable-line no-param-reassign
+  }
+
+  const filters: FilterDict = {};
+
+  // searchable fields + path
+  [...fields, 'path'].forEach((field) => {
+    filters[field] = new Filter(
+      fieldEqPredicateIgnoreNullBuilder(field),
+      GraphQLString,
+    );
+  });
+
+  // generic filter object
+  filters.filter = new Filter(
+    filterObjectPredicateBuilder(gqlType, app, bundleSha),
+    jsonType,
+  );
+
+  app.get('searchableFields')[bundleSha][gqlType.name] = filters; // eslint-disable-line no-param-reassign
+};
+
+// interface types helpers
+const addInterfaceType = (app: express.Express, bundleSha: string, name: string, obj: any) => {
+  if (typeof (app.get('objectInterfaces')[bundleSha]) === 'undefined') {
+    app.get('objectInterfaces')[bundleSha] = {}; // eslint-disable-line no-param-reassign
+  }
+  app.get('objectInterfaces')[bundleSha][name] = obj; // eslint-disable-line no-param-reassign
+};
+
+// datafile types to GraphQL type
+const addDatafileSchema = (
+  app: express.Express,
+  bundleSha: string,
+  datafileSchema: string,
+  graphqlType: string,
+) => {
+  if (typeof (app.get('datafileSchemas')[bundleSha]) === 'undefined') {
+    app.get('datafileSchemas')[bundleSha] = {}; // eslint-disable-line no-param-reassign
+  }
+  app.get('datafileSchemas')[bundleSha][datafileSchema] = graphqlType; // eslint-disable-line no-param-reassign
+};
+
+const getGraphqlTypeForDatafileSchema = (
+  app: express.Express,
+  bundleSha: string,
+  datafileSchema: string,
+) => app.get('datafileSchemas')[bundleSha][datafileSchema];
+
+// synthetic field resolver
+const resolveSyntheticField = (
+  bundle: db.Bundle,
+  path: string,
+  schema: string,
+  subAttr: string,
+): Datafile[] => bundle.syntheticBackRefTrie.getDatafiles(schema, subAttr.split('.'), path);
+
+const resolveDatafileSchemaField = (
+  bundle: db.Bundle,
+  schema: string,
+  searchableFields: FilterDict,
+  args: any,
+): Datafile[] => {
+  // that get is not guaranteed to return a value so if it doesn't, we will just return
+  // undefined from the function rather than cause an error
+  const datafiles = bundle.datafilesBySchema.get(schema);
+
+  if (!datafiles) return [];
+
+  const filterArgs = Object.entries(args)
+    .filter(([_, value]) => value != null); // eslint-disable-line no-unused-vars
+
+  const predicates = filterArgs.map(
+    ([key, value]) => searchableFields[key].predicateBuilder(value),
+  );
+  return datafiles
+    .filter((df: Datafile) => predicates.every((predicate) => predicate(df)));
+};
+
+const getInnerGqlType = (
+  gqlType: any,
+): any => {
+  if ('ofType' in gqlType) {
+    return getInnerGqlType(gqlType.ofType);
+  }
+  return gqlType;
+};
+
+// default resolver
+export const defaultResolver = (
+  app: express.Express,
+  bundleSha: string,
+) => (root: any, args: any, context: any, info: any) => {
+  const resolved = resolveValue(app, bundleSha, root, args, context, info);
+  if (Object.keys(args).length !== 0) {
+    const filterSpecs = getFilters(app, bundleSha, getInnerGqlType(info.returnType));
+    const filterArgs = Object.entries(args)
+      .filter(([_, value]) => value != null); // eslint-disable-line no-unused-vars
+
+    const predicates = filterArgs.map(
+      ([key, value]) => filterSpecs[key].predicateBuilder(value),
+    );
+    if (Array.isArray(resolved)) {
+      return resolved.filter((e) => predicates.every((predicate) => predicate(e)));
+    }
+    return !predicates.every((predicate) => predicate(resolved));
+  }
+  return resolved;
+};
+
 // ------------------ START SCHEMA ------------------
 
 const createSchemaType = (app: express.Express, bundleSha: string, conf: any) => {
@@ -283,13 +407,6 @@ const createSchemaType = (app: express.Express, bundleSha: string, conf: any) =>
 
   // name
   objTypeConf.name = conf.name;
-
-  // searchable fields
-  const searchableFieldNames = conf.fields
-    .filter((f: any) => f.isSearchable && f.type === 'string')
-    .map((f: any) => f.name);
-
-  registerFilterArgs(app, bundleSha, conf, searchableFieldNames);
 
   // fields
   objTypeConf.fields = () => conf.fields.reduce(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -196,7 +196,7 @@ const conditionsObjectPredicate = (
   );
 };
 
-const conditionsObjectPredicateDeconstuctor = (
+const conditionsObjectPredicateDeconstructor = (
   field: string,
   value: any,
   fieldGqlType: any,
@@ -267,7 +267,7 @@ const filterObjectPredicateBuilder = (
             arrayEqPredicate('values', value, { values: extractListOfValues(app, bundleSha, field, source) })
           );
         case isConditionsObject(value):
-          return conditionsObjectPredicateDeconstuctor.bind(
+          return conditionsObjectPredicateDeconstructor.bind(
             null,
             field,
             value,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -151,12 +151,8 @@ const extractListOfValues = (
   field: string,
   source: any,
 ): any[] => {
-  if (Array.isArray(source)) {
-    return source.map((e: any) => resolveValue(app, bundleSha, e, null, {}, { fieldName: field }));
-  }
-  return [
-    resolveValue(app, bundleSha, source, null, {}, { fieldName: field }),
-  ];
+  const sources = Array.isArray(source) ? source : [source];
+  return sources.map((e: any) => resolveValue(app, bundleSha, e, null, {}, { fieldName: field }));
 };
 
 const getFilters = (

--- a/test/filter/data.json
+++ b/test/filter/data.json
@@ -30,52 +30,91 @@
         "name": "resource F",
         "optional_field": "F",
         "list_field": ["C", "D", "E"]
-      }
-    },
-    "graphql": [
-      {
-        "name": "Resource_v1",
-        "fields": [
+      },
+      "/resource-g.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource G",
+        "reference": {
+          "$ref": "/resource-a.yml"
+        }
+      },
+      "/resource-h.yml": {
+        "$schema": "/resource-1.yml",
+        "name": "resource H",
+        "reference": {
+          "$ref": "/resource-d.yml"
+        },
+        "reference_list": [
           {
-            "isRequired": true,
-            "type": "string",
-            "name": "schema"
+            "$ref": "/resource-a.yml"
           },
           {
-            "isRequired": true,
-            "type": "string",
-            "name": "path"
+            "$ref": "/resource-b.yml"
           },
           {
-            "type": "string",
-            "name": "name",
-            "isRequired": true,
-            "isSearchable": true
-          },
-          {
-            "type": "string",
-            "name": "optional_field",
-            "isRequired": false
-          },
-          {
-            "type": "string",
-            "name": "list_field",
-            "isList": true,
-            "isRequired": false
+            "$ref": "/resource-c.yml"
           }
         ]
-      },
-      {
-        "fields": [
-            {
-                "type": "Resource_v1",
-                "name": "resources_v1",
+      }
+    },
+    "graphql": {
+        "$schema" : "/app-interface/graphql-schemas-1.yml",
+        "confs": [
+          {
+            "name": "Resource_v1",
+            "fields": [
+              {
+                "isRequired": true,
+                "type": "string",
+                "name": "schema"
+              },
+              {
+                "isRequired": true,
+                "type": "string",
+                "name": "path"
+              },
+              {
+                "type": "string",
+                "name": "name",
+                "isRequired": true,
+                "isSearchable": true
+              },
+              {
+                "type": "string",
+                "name": "optional_field",
+                "isRequired": false
+              },
+              {
+                "type": "string",
+                "name": "list_field",
                 "isList": true,
-                "datafileSchema": "/resource-1.yml"
-            }
-        ],
-        "name": "Query"
-    }
-    ],
+                "isRequired": false
+              },
+              {
+                "type": "Resource_v1",
+                "name": "reference",
+                "isRequired": false
+              },
+              {
+                "type": "Resource_v1",
+                "name": "reference_list",
+                "isList": true,
+                "isRequired": false
+              }
+            ]
+          },
+          {
+            "fields": [
+                {
+                    "type": "Resource_v1",
+                    "name": "resources_v1",
+                    "isList": true,
+                    "datafileSchema": "/resource-1.yml"
+                }
+            ],
+            "name": "Query"
+          }
+        ]
+    },
     "resources": {}
 }

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -69,6 +69,22 @@ describe('pathobject', async () => {
     resp.body.data.test[0].name.should.equal('resource A');
   });
 
+  it('filter object - unknown field', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {unknown_field: "resource A"}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.errors[0].message.should.equal('Field "unknown_field" does not exist on type "Resource_v1"');
+  });
+
   it('filter object - in (contains) condition', async () => {
     const query = `
       {
@@ -165,6 +181,22 @@ describe('pathobject', async () => {
     resp.should.have.status(200);
     resp.body.data.test.length.should.equal(1);
     resp.body.data.test[0].name.should.equal('resource G');
+  });
+
+  it('filter object - referenced object - unknown field', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {reference: {filter: {unknown_field: "resource A"}}}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.errors[0].message.should.equal('Field "unknown_field" does not exist on type "Resource_v1"');
   });
 
   it('filter object - referenced object - field null', async () => {

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -50,7 +50,7 @@ describe('pathobject', async () => {
       .set('content-type', 'application/json')
       .send({ query });
     resp.should.have.status(200);
-    resp.body.data.test.length.should.equal(6);
+    resp.body.data.test.length.should.equal(8);
   });
 
   it('filter object - field value eq', async () => {
@@ -114,7 +114,7 @@ describe('pathobject', async () => {
       .set('content-type', 'application/json')
       .send({ query });
     resp.should.have.status(200);
-    resp.body.data.test.length.should.equal(1);
+    resp.body.data.test.length.should.equal(3);
     resp.body.data.test[0].name.should.equal('resource D');
   });
 
@@ -147,6 +147,74 @@ describe('pathobject', async () => {
       .set('content-type', 'application/json')
       .send({ query });
     resp.should.have.status(200);
-    new Set(resp.body.data.test.map((r: { name: string; }) => r.name)).should.deep.equal(new Set(['resource A', 'resource B', 'resource C', 'resource D']));
+    new Set(resp.body.data.test.map((r: { name: string; }) => r.name)).should.deep.equal(new Set(['resource A', 'resource B', 'resource C', 'resource D', 'resource G', 'resource H']));
+  });
+
+  it('filter object - referenced object - field value eq', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {reference: {filter: {name: "resource A"}}}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.equal(1);
+    resp.body.data.test[0].name.should.equal('resource G');
+  });
+
+  it('filter object - referenced object - field null', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {reference: {filter: {optional_field: null}}}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.equal(1);
+    resp.body.data.test[0].name.should.equal('resource H');
+  });
+
+  it('filter object - referenced object - list field eq', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {reference_list: {filter: {name: ["resource A", "resource B", "resource C"]}}}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.equal(1);
+    resp.body.data.test[0].name.should.equal('resource H');
+  });
+
+  it('filter object - referenced object - list field in', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {reference_list: {filter: {name: {in: ["resource A", "resource B", "resource C", "resource D"]}}}}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.equal(1);
+    resp.body.data.test[0].name.should.equal('resource H');
   });
 });

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -216,23 +216,6 @@ describe('pathobject', async () => {
     resp.body.data.test[0].name.should.equal('resource H');
   });
 
-  it('filter object - referenced object - list field eq', async () => {
-    const query = `
-      {
-        test: resources_v1(filter: {reference_list: {filter: {name: ["resource A", "resource B", "resource C"]}}}) {
-          name
-        }
-      }
-      `;
-    const resp = await chai.request(srv)
-      .post('/graphql')
-      .set('content-type', 'application/json')
-      .send({ query });
-    resp.should.have.status(200);
-    resp.body.data.test.length.should.equal(1);
-    resp.body.data.test[0].name.should.equal('resource H');
-  });
-
   it('filter object - referenced object - list field in', async () => {
     const query = `
       {


### PR DESCRIPTION
based on the filtering functionality introduced in https://github.com/app-sre/qontract-server/pull/209, this PR adds new filtering capabilities for nested objects.

reminder: the filtering functionality currently present was designed after [dgraphs filtering proposal](https://dgraph.io/docs/graphql/queries/search-filtering/), so basically via an argument called `filter`, e.g.

* filter based on an attributes value `filter: { name: "some name" }`
* filter on list membership `filter: { names: { in: ['name one", "name two" ] } }`

this `filter` argument was applicable only to top level fields of a GQL type, but now it can be applied to filter on nested objects by nesting `filter`s

this example query will return information for clusters of a specific organization. the `filter` argument is nested under the `ocm` property, which describes the organization of a cluster.

```gql
{
  clusters: cluster_v1(filter: {
    ocm: {
      filter: {
        orgId: "some org id"
      }
    }
  }) {
    name
  }
}
```