### PR TITLE
non-equal filter predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,36 @@ To filter on an fields value, use the following filter object syntax
 
 This way only resources with such a field and value are returned by the query.
 
+Also works for null.
+
+```json
+"filter": {
+    "my_field": null
+}
+```
+
+### Field not-equal predicate
+
+To check if a property value is not equal to a certain value, use the `ne` filter predicate
+
+```json
+"filter": {
+    "my_field": {
+        "ne": "my_value"
+    }
+}
+```
+
+This also works to check for missing values or references.
+
+```json
+"filter": {
+    "my_field": {
+        "ne": null
+    }
+}
+```
+
 ### List contains predicate
 
 Field values can be also compared towards a list of acceptable values.

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -66,6 +66,11 @@ const fieldEqPredicate = (field: string, value: any, source: any): boolean => (
   (source[field] ?? null) === value
 );
 
+const fieldNotEqualPredicate = (field: string, value: any, source: any): boolean => {
+  const sourceValue = (source[field] ?? null);
+  return value !== sourceValue;
+};
+
 const arrayEqPredicate = (field: string, comparisonArray: any, source: any): boolean => {
   const sourceArray = (source[field] ?? null);
   if (sourceArray === comparisonArray) {
@@ -156,7 +161,9 @@ const isConditionsObject = (
   if (conditionsObject == null) {
     return false;
   }
-  return Object.prototype.hasOwnProperty.call(conditionsObject, 'in') || Object.prototype.hasOwnProperty.call(conditionsObject, 'filter');
+  return Object.prototype.hasOwnProperty.call(conditionsObject, 'in')
+    || Object.prototype.hasOwnProperty.call(conditionsObject, 'filter')
+    || Object.prototype.hasOwnProperty.call(conditionsObject, 'ne');
 };
 
 const filterPredicate = (
@@ -186,6 +193,9 @@ const conditionsObjectPredicate = (
   }
   if (Object.prototype.hasOwnProperty.call(value, 'filter')) {
     return filterPredicate(field, value.filter, fieldGqlType, app, bundleSha, source);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'ne')) {
+    return fieldNotEqualPredicate(field, value.ne, source);
   }
   throw new GraphQLError(
     `Condition object ${value} unsupported`,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -155,15 +155,17 @@ const getFilters = (
   name: string,
 ): FilterDict => app.get('searchableFields')[bundleSha][name];
 
+const SUPPORTED_FILTER_OPERATORS = ['in', 'filter', 'ne'];
+
 const isConditionsObject = (
   conditionsObject: any,
 ): boolean => {
   if (conditionsObject == null) {
     return false;
   }
-  return Object.prototype.hasOwnProperty.call(conditionsObject, 'in')
-    || Object.prototype.hasOwnProperty.call(conditionsObject, 'filter')
-    || Object.prototype.hasOwnProperty.call(conditionsObject, 'ne');
+  return SUPPORTED_FILTER_OPERATORS.some((operator) => (
+    Object.prototype.hasOwnProperty.call(conditionsObject, operator)
+  ));
 };
 
 const filterPredicate = (

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -134,6 +134,48 @@ describe('pathobject', async () => {
     resp.body.data.test[0].name.should.equal('resource D');
   });
 
+  it('filter object - non-null field value', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {reference: { ne: null }}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.be.above(0);
+    resp.body.data.test.forEach((r: { reference?: any; }) => {
+      if (r.reference !== undefined && r.reference !== null) {
+        throw new Error('reference should be undefined or null');
+      }
+    });
+  });
+
+  it('filter object - not-equal field value', async () => {
+    const query = `
+      {
+        test: resources_v1(filter: {optional_field: { ne: "E" }}) {
+          name
+        }
+      }
+      `;
+    const resp = await chai.request(srv)
+      .post('/graphql')
+      .set('content-type', 'application/json')
+      .send({ query });
+    resp.should.have.status(200);
+    resp.body.data.test.length.should.be.above(0);
+    resp.body.data.test.forEach((r: { optional_field?: string; }) => {
+      if (r.optional_field !== undefined && r.optional_field === 'E') {
+        throw new Error('optional_field should not have value "E"');
+      }
+    });
+  });
+
   it('filter object - list field eq', async () => {
     const query = `
       {

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -174,9 +174,7 @@ describe('pathobject', async () => {
     resp.should.have.status(200);
     resp.body.data.test.length.should.be.above(0);
     resp.body.data.test.forEach((r: { optional_field?: string; }) => {
-      if (r.optional_field) {
-        r.optional_field.should.not.equal('E');
-      }
+      should.not.equal(r.optional_field, 'E');
     });
   });
 

--- a/test/filter/filter.test.ts
+++ b/test/filter/filter.test.ts
@@ -12,6 +12,8 @@ import * as db from '../../src/db';
 chai.use(chaiHttp);
 chai.should();
 
+const should = chai.should();
+
 describe('pathobject', async () => {
   let srv: http.Server;
   before(async () => {
@@ -139,6 +141,9 @@ describe('pathobject', async () => {
       {
         test: resources_v1(filter: {reference: { ne: null }}) {
           name
+          reference {
+            name
+          }
         }
       }
       `;
@@ -149,9 +154,7 @@ describe('pathobject', async () => {
     resp.should.have.status(200);
     resp.body.data.test.length.should.be.above(0);
     resp.body.data.test.forEach((r: { reference?: any; }) => {
-      if (r.reference !== undefined && r.reference !== null) {
-        throw new Error('reference should be undefined or null');
-      }
+      should.exist(r.reference);
     });
   });
 
@@ -160,6 +163,7 @@ describe('pathobject', async () => {
       {
         test: resources_v1(filter: {optional_field: { ne: "E" }}) {
           name
+          optional_field
         }
       }
       `;
@@ -170,8 +174,8 @@ describe('pathobject', async () => {
     resp.should.have.status(200);
     resp.body.data.test.length.should.be.above(0);
     resp.body.data.test.forEach((r: { optional_field?: string; }) => {
-      if (r.optional_field !== undefined && r.optional_field === 'E') {
-        throw new Error('optional_field should not have value "E"');
+      if (r.optional_field) {
+        r.optional_field.should.not.equal('E');
       }
     });
   });


### PR DESCRIPTION
following up on https://github.com/app-sre/qontract-server/pull/215, this PR introduces a filter predicate to check for not-equal, including null.

```json
"filter": {
    "my_field": {
        "ne": "my_value"
    }
}
```

```json
"filter": {
    "my_field": {
        "ne": null
    }
}
```

part of https://issues.redhat.com/browse/APPSRE-8502