### PR TITLE
APPSRE-10953 optional pull secrets

### DIFF
--- a/openshift/app-interface.autoscale.yaml
+++ b/openshift/app-interface.autoscale.yaml
@@ -6,6 +6,7 @@ metadata:
 objects:
 - apiVersion: v1
   kind: ServiceAccount
+  imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
   metadata:
     name: app-interface
 - apiVersion: policy/v1
@@ -277,6 +278,9 @@ parameters:
   value: latest
   displayName: App interface version
   description: App interface version which defaults to latest
+- name: IMAGE_PULL_SECRETS
+  value: '[]'
+  description: Secrets to use for pulling qontract-server images
 - name: MIN_REPLICAS
   value: "3"
 - name: MAX_REPLICAS

--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -6,6 +6,7 @@ metadata:
 objects:
 - apiVersion: v1
   kind: ServiceAccount
+  imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
   metadata:
     name: app-interface
 - apiVersion: policy/v1
@@ -264,6 +265,9 @@ parameters:
   value: latest
   displayName: App interface version
   description: App interface version which defaults to latest
+- name: IMAGE_PULL_SECRETS
+  value: '[]'
+  description: Secrets to use for pulling qontract-server images
 - name: REPLICAS
   value: "1"
 - name: IMAGE_GATE


### PR DESCRIPTION
Lets allow to set optional pull secrets as we do for github-mirror https://github.com/app-sre/github-mirror/blob/7ec5f47db6712c784bac0b38896e5fbfeec71b52/openshift/github-mirror.yaml#L20

Currently Konflux repos are always private ( https://issues.redhat.com/browse/RELEASE-1152).
In order to make a repository public, we need to submit a manual request to the Konflux team. We are in the process of integrating all repos and compiling a list that we will submit to them.

Until then, we can already start to optionally pull from private repo. Having this option doesnt harm.