### PR TITLE
APPSRE-11019 updates and explicit prod build target

### DIFF
--- a/.tekton/qontract-server-master-push.yaml
+++ b/.tekton/qontract-server-master-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: target-stage
+    value: prod
   pipelineRef:
     params:
     - name: url

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-18 as base
+FROM registry.access.redhat.com/ubi9/nodejs-20 as base
 RUN npm install -g yarn && npm cache clean --force
 WORKDIR $HOME
 COPY package.json yarn.lock ./
@@ -11,15 +11,19 @@ RUN yarn build
 
 FROM dev as test
 RUN yarn run lint && yarn test
+RUN echo "true" > /tmp/is_tested && chmod 777 /tmp/is_tested
 
-FROM base as prod
+FROM base as pre-prod
 RUN yarn install --frozen-lockfile --production && \
     yarn cache clean
 
-FROM registry.access.redhat.com/ubi8/nodejs-18-minimal
+# TODO: use minimal image registry.access.redhat.com/ubi9/nodejs-20-minimal
+FROM registry.access.redhat.com/ubi9/nodejs-20 as prod
 WORKDIR $HOME
-COPY --from=prod $HOME/node_modules $HOME/node_modules
+COPY --from=pre-prod $HOME/node_modules $HOME/node_modules
 COPY --from=dev ${HOME}/dist ./dist
+# Ensure test is triggered on main push
+COPY --from=test /tmp/is_tested /tmp/is_tested
 EXPOSE 4000
 ENV NODE_ENV=production
 ENV NODE_OPTIONS="--max-old-space-size=4096"

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ docker-run-clean:
 	@$(CONTAINER_ENGINE) rm -f $(VALIDATOR_CONTAINER_NAME) || true
 
 build:
-	@$(CONTAINER_ENGINE) build --pull -t $(IMAGE_NAME):latest .
+	@$(CONTAINER_ENGINE) build --pull --target=prod -t $(IMAGE_NAME):latest .
 	@$(CONTAINER_ENGINE) tag $(IMAGE_NAME):latest $(IMAGE_NAME):$(IMAGE_TAG)
 
 push:


### PR DESCRIPTION
Making qontract-server konflux compliant.

Lets have a dedicated explicit prod target that is explicitly used by konflux (and ci.ext for now). 

Also bump to ubi9

Further, the `nodejs-18-minimal` fails for sbom generation stage and non minimal image fails deprecation check:

```
[FAILURE] Image registry.access.redhat.com/ubi9/nodejs-18 has been deprecated
```

New nodejs-20-minimal image also fails sbom generation check:

```
AssertionError: Cannot get information about base image registry.access.redhat.com/ubi9/nodejs-20-minimal mentioned in the Dockerfile!
```

Using non-minimal image for now to get compliant build.

Running image locally works

```
make docker-run
(node:1) NOTE: The AWS SDK for JavaScript (v2) will enter maintenance mode
on September 8, 2024 and reach end-of-support on September 8, 2025.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check blog post at https://a.co/cUPnyil
(Use `node --trace-warnings ...` to show where the warning was created)
2025-07-30T12:26:16.421Z INFO: loading initial bundle 239733186bdf144232dd77e16ec0f45dda30df70173dd89dcdb7cd06651018b8
2025-07-30T12:26:16.605Z INFO: Running at http://localhost:4000/graphql
```