### PR TITLE
chore(deps): upgrade graphql 14 to 15 and update @types/express (phas…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,14 @@
         "dotenv": "^16.6.1",
         "express": "^4.16.4",
         "express-prom-bundle": "^6.0.0",
-        "graphql": "^14.7.0",
+        "graphql": "^15.10.2",
         "jsonpointer": "^5.0.1",
         "prom-client": "^12.0.0",
         "winston": "^3.19.0"
       },
       "devDependencies": {
         "@types/chai": "4.3.12",
-        "@types/express": "4.16.1",
-        "@types/graphql": "14.5.0",
+        "@types/express": "^4.17.25",
         "@types/mocha": "10.0.10",
         "@typescript-eslint/eslint-plugin": "5.60.1",
         "@typescript-eslint/parser": "5.60.1",
@@ -2056,16 +2055,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cookies/node_modules/@types/express": {
-      "version": "4.17.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
     "node_modules/@types/cookies/node_modules/@types/node": {
       "version": "14.11.8",
       "license": "MIT"
@@ -2077,33 +2066,28 @@
         "@types/express": "*"
       }
     },
-    "node_modules/@types/cors/node_modules/@types/express": {
-      "version": "4.17.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
     "node_modules/@types/express": {
-      "version": "4.16.1",
-      "dev": true,
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.13",
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/fs-capacitor": {
@@ -2111,14 +2095,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/graphql": {
-      "version": "14.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graphql": "*"
       }
     },
     "node_modules/@types/graphql-upload": {
@@ -2129,31 +2105,6 @@
         "@types/fs-capacitor": "*",
         "@types/koa": "*",
         "graphql": "^15.3.0"
-      }
-    },
-    "node_modules/@types/graphql-upload/node_modules/@types/express": {
-      "version": "4.17.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/graphql-upload/node_modules/graphql": {
-      "version": "15.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/@types/graphql/node_modules/graphql": {
-      "version": "15.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
       }
     },
     "node_modules/@types/http-assert": {
@@ -2248,6 +2199,15 @@
       "version": "7.5.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.5",
@@ -2694,6 +2654,55 @@
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
+    "node_modules/apollo-server-core/node_modules/graphql-upload": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+      "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^2.0.4",
+        "http-errors": "^1.7.3",
+        "object-path": "^0.11.4"
+      },
+      "engines": {
+        "node": ">=8.5"
+      },
+      "peerDependencies": {
+        "graphql": "0.13.1 - 14"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/apollo-server-core/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/apollo-server-core/node_modules/uuid": {
       "version": "8.3.1",
       "license": "MIT",
@@ -2770,15 +2779,6 @@
     },
     "node_modules/apollo-server-express/node_modules/@types/express-serve-static-core": {
       "version": "4.17.9",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "node_modules/apollo-server-express/node_modules/@types/express/node_modules/@types/express-serve-static-core": {
-      "version": "4.17.13",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -3129,6 +3129,8 @@
     },
     "node_modules/busboy": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
       "dependencies": {
         "dicer": "0.3.0"
       },
@@ -3672,6 +3674,8 @@
     },
     "node_modules/dicer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
       "dependencies": {
         "streamsearch": "0.1.2"
       },
@@ -4571,6 +4575,8 @@
     },
     "node_modules/fs-capacitor": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
+      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.5"
@@ -4814,13 +4820,12 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "14.7.0",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.2.tgz",
+      "integrity": "sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==",
       "license": "MIT",
-      "dependencies": {
-        "iterall": "^1.2.2"
-      },
       "engines": {
-        "node": ">= 6.x"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-extensions": {
@@ -4839,13 +4844,15 @@
       }
     },
     "node_modules/graphql-subscriptions": {
-      "version": "1.1.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+      "integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
       "license": "MIT",
       "dependencies": {
-        "iterall": "^1.2.1"
+        "iterall": "^1.3.0"
       },
       "peerDependencies": {
-        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/graphql-tag": {
@@ -4868,40 +4875,6 @@
       "peerDependencies": {
         "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0"
       }
-    },
-    "node_modules/graphql-upload": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "busboy": "^0.3.1",
-        "fs-capacitor": "^2.0.4",
-        "http-errors": "^1.7.3",
-        "object-path": "^0.11.4"
-      },
-      "engines": {
-        "node": ">=8.5"
-      },
-      "peerDependencies": {
-        "graphql": "0.13.1 - 14"
-      }
-    },
-    "node_modules/graphql-upload/node_modules/http-errors": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/graphql-upload/node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5940,6 +5913,8 @@
     },
     "node_modules/object-path": {
       "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.12.0"
@@ -6932,6 +6907,8 @@
     },
     "node_modules/streamsearch": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
       "engines": {
         "node": ">=0.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,15 +24,14 @@
     "dotenv": "^16.6.1",
     "express": "^4.16.4",
     "express-prom-bundle": "^6.0.0",
-    "graphql": "^14.7.0",
+    "graphql": "^15.10.2",
     "jsonpointer": "^5.0.1",
     "prom-client": "^12.0.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {
     "@types/chai": "4.3.12",
-    "@types/express": "4.16.1",
-    "@types/graphql": "14.5.0",
+    "@types/express": "^4.17.25",
     "@types/mocha": "10.0.10",
     "@typescript-eslint/eslint-plugin": "5.60.1",
     "@typescript-eslint/parser": "5.60.1",


### PR DESCRIPTION
…e 2)

- graphql: ^14.7.0 -> ^15.10.2 (ships own types, no @types/graphql needed)
- Remove @types/graphql devDependency (obsolete with graphql 15+)
- @types/express: 4.16.1 -> ^4.17.25

graphql 15 is backwards-compatible with 14, no source code changes required. Peer dependency warning from graphql-upload in apollo-server-core 2.x is expected and will be resolved in Phase 4b (Apollo Server 4 migration).

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>