### PR TITLE
chore(deps): upgrade prom-client 12 to 15 and express-prom-bundle 6 t…

### DIFF
--- a/docs/dependency-upgrade-plan.md
+++ b/docs/dependency-upgrade-plan.md
@@ -71,8 +71,9 @@ Intermediate step: graphql 15 is compatible with both apollo-server-express 2 an
   // After:
   app.get('/metrics', async (req, res) => { res.send(await promClient.register.metrics()); });
   ```
-- `src/metrics.ts:24`: verify `collectDefaultMetrics({ prefix: ... })` still works (it does in prom-client 15)
-- Check for double-registration of default metrics between `metrics.ts` and `express-prom-bundle`
+- `src/metrics.ts:24`: `collectDefaultMetrics({ prefix: ... })` still works unchanged in prom-client 15 ✓
+- No double-registration issues between `metrics.ts` and `express-prom-bundle@8` ✓
+- `express-prom-bundle@8` configuration in `src/metrics.ts` required no changes ✓
 
 **Verify:** `npm test` + manual `curl http://localhost:4000/metrics` to confirm valid Prometheus output
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "deep-diff": "1.0.2",
         "dotenv": "^16.6.1",
         "express": "^4.16.4",
-        "express-prom-bundle": "^6.0.0",
+        "express-prom-bundle": "^8.0.0",
         "graphql": "^15.10.2",
         "jsonpointer": "^5.0.1",
-        "prom-client": "^12.0.0",
+        "prom-client": "^15.1.3",
         "winston": "^3.19.0"
       },
       "devDependencies": {
@@ -1190,6 +1190,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -3057,7 +3066,10 @@
       "license": "MIT"
     },
     "node_modules/bintrees": {
-      "version": "1.0.1"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.19.0",
@@ -4272,17 +4284,53 @@
       }
     },
     "node_modules/express-prom-bundle": {
-      "version": "6.0.0",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-8.0.0.tgz",
+      "integrity": "sha512-UHdpaMks6Z/tvxQsNzhsE7nkdXb4/zEh/jwN0tfZSZOEF+aD0dlfl085EU4jveOq09v01c5sIUfjV4kJODZ2eQ==",
       "license": "MIT",
       "dependencies": {
+        "@types/express": "^5.0.0",
         "on-finished": "^2.3.0",
         "url-value-parser": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "prom-client": "^12.0.0"
+        "prom-client": ">=15.0.0"
+      }
+    },
+    "node_modules/express-prom-bundle/node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/express-prom-bundle/node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/express-prom-bundle/node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -6247,13 +6295,16 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "12.0.0",
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/proxy-addr": {
@@ -7150,10 +7201,12 @@
       }
     },
     "node_modules/tdigest": {
-      "version": "0.1.1",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
       "license": "MIT",
       "dependencies": {
-        "bintrees": "1.0.1"
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-hex": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "deep-diff": "1.0.2",
     "dotenv": "^16.6.1",
     "express": "^4.16.4",
-    "express-prom-bundle": "^6.0.0",
+    "express-prom-bundle": "^8.0.0",
     "graphql": "^15.10.2",
     "jsonpointer": "^5.0.1",
-    "prom-client": "^12.0.0",
+    "prom-client": "^15.1.3",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -375,8 +375,8 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
     res.send(JSON.stringify(gitCommitInfo));
   });
 
-  app.get('/metrics', (req: express.Request, res: express.Response) => {
-    res.send(promClient.register.metrics());
+  app.get('/metrics', async (req: express.Request, res: express.Response) => {
+    res.send(await promClient.register.metrics());
   });
 
   app.get('/cache', (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
…o 8 (phase 3)

- prom-client: ^12.0.0 -> ^15.1.3
- express-prom-bundle: ^6.0.0 -> ^8.0.0
- src/server.ts: make /metrics handler async (register.metrics() returns a Promise in prom-client 13+)
- docs: update plan with Phase 3 verified findings

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>