### PR TITLE
refactor: replace _router.stack manipulation with shaRouters Map (pha…

### DIFF
--- a/docs/dependency-upgrade-plan.md
+++ b/docs/dependency-upgrade-plan.md
@@ -89,12 +89,13 @@ Intermediate step: graphql 15 is compatible with both apollo-server-express 2 an
 - `src/metrics.ts:54` — gauge for stack length
 
 **Approach:** Replace with a `Map<string, express.Router>` dispatch pattern:
-- Create a `Map<string, express.Router>` for per-SHA routers
-- Mount a single top-level middleware at `/graphqlsha` that dispatches to the correct sub-router by SHA
+- Store map in app state as `'shaRouters'` (`Map<string, express.Router>`)
+- Each Apollo middleware is registered with the full path `/graphqlsha/<sha>` via `getMiddleware()` and stored in the map (no `app.use()` call)
+- A single top-level middleware dispatches `/graphqlsha/:sha` requests by SHA lookup, passing `req.url` unchanged (no prefix stripping needed since Apollo is configured with the full path)
 - On expiration, `shaRouters.delete(sha)` instead of stack splicing
 - `/cache` and metrics report `shaRouters.size` instead of `_router.stack.length`
 
-**Test changes:** `test/multishas/multishas.test.ts` lines 130, 140 reference `_router.stack.length` — update to new mechanism.
+**Test changes:** `test/multishas/multishas.test.ts` lines 130, 140 reference `_router.stack.length` — replace with `app.get('shaRouters').size`.
 
 **Verify:** `npm test` + manual multi-SHA reload test
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -51,7 +51,7 @@ const bundleCacheGauge = new promClient.Gauge({
 });
 
 export const updateCacheMetrics = (app: express.Express) => {
-  routerStackGauge.set(app._router.stack.length); // eslint-disable-line no-underscore-dangle
+  routerStackGauge.set(app.get('shaRouters').size);
   bundleGauge.set(Object.keys(app.get('bundles')).length);
   bundleCacheGauge.set(Object.keys(app.get('bundleCache')).length);
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,20 +16,19 @@ const BUNDLE_SHA_TTL = Number(process.env.BUNDLE_SHA_TTL) || 20 * 60 * 1000;
 // Interfaces
 interface ICacheInfo {
   expiration: number;
-  serverMiddleware: express.Router;
 }
 
 // registers a new ApolloServer into the app router and cache
 const registerApolloServer = (app: express.Express, bundleSha: string, server: any) => {
+  // getMiddleware returns a Router configured for the full path; store it in the Map
   const serverMiddleware = server.getMiddleware({ path: `/graphqlsha/${bundleSha}` });
   const expiration = Date.now() + BUNDLE_SHA_TTL;
 
-  app.use(serverMiddleware);
+  app.get('shaRouters').set(bundleSha, serverMiddleware);
 
   // add to the cache
   // eslint-disable-next-line no-param-reassign
   app.get('bundleCache')[bundleSha] = {
-    serverMiddleware,
     expiration,
   } as ICacheInfo;
 
@@ -92,7 +91,6 @@ const buildApolloServer = (app: express.Express, bundleSha: string): ApolloServe
 
 // remove expired bundles
 const removeExpiredBundles = (app: express.Express) => {
-  // remove expired bundles
   // eslint-disable-next-line no-restricted-syntax
   for (const [sha, cacheInfoObj] of Object.entries(app.get('bundleCache'))) {
     if (sha === app.get('latestBundleSha')) {
@@ -101,19 +99,12 @@ const removeExpiredBundles = (app: express.Express) => {
 
     const cacheInfo = cacheInfoObj as ICacheInfo;
     if (cacheInfo.expiration < Date.now()) {
-      // removing sha
       logger.info('removing expired bundle: %s', sha);
       // eslint-disable-next-line no-param-reassign
       delete app.get('bundles')[sha];
 
-      // remove from router. NOTE: this is not officially supported and may break in future
-      // versions of express without warning.
-      // eslint-disable-next-line no-underscore-dangle
-      const index = app._router.stack.findIndex(
-        (m: any) => m.handle === cacheInfo.serverMiddleware,
-      );
-      // eslint-disable-next-line no-underscore-dangle
-      app._router.stack.splice(index, 1);
+      // remove from shaRouters map — no router stack manipulation needed
+      app.get('shaRouters').delete(sha);
 
       // remove from bundleCache
       delete app.get('bundleCache')[sha]; // eslint-disable-line no-param-reassign
@@ -145,6 +136,9 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
   // Create cache object
   app.set('bundleCache', {});
 
+  // Per-SHA router map: sha -> Apollo middleware (configured with full /graphqlsha/<sha> path)
+  app.set('shaRouters', new Map<string, express.Router>());
+
   // Middleware for prom metrics
   app.use(metrics.metricsMiddleware);
 
@@ -174,6 +168,21 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
       }
     }
 
+    next();
+  });
+
+  // Single dispatcher for all /graphqlsha/:sha requests — routes to the correct Apollo middleware.
+  // Each middleware was configured with the full path, so req.url is passed through unchanged.
+  app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const match = req.url.match(/^\/graphqlsha\/([^/?]+)/);
+    if (match) {
+      const sha = match[1];
+      const handler = app.get('shaRouters').get(sha);
+      if (handler) {
+        handler(req, res, next);
+        return;
+      }
+    }
     next();
   });
 
@@ -389,8 +398,7 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
     }
 
     fullCacheInfo.bundles = Object.keys(req.app.get('bundles'));
-    // eslint-disable-next-line no-underscore-dangle
-    fullCacheInfo.routerStack = app._router.stack.length;
+    fullCacheInfo.routerStack = app.get('shaRouters').size;
     fullCacheInfo.searchableFields = Object.keys(req.app.get('searchableFields'));
 
     res.send(JSON.stringify(fullCacheInfo));

--- a/test/multishas/multishas.test.ts
+++ b/test/multishas/multishas.test.ts
@@ -126,8 +126,7 @@ describe('multishas', async () => {
 
   it('removes expired bundle', async () => {
     const sha: string = Object.keys(app.get('bundles'))[0];
-    // eslint-disable-next-line no-underscore-dangle
-    const stackLen = app._router.stack.length;
+    const routersBefore = app.get('shaRouters').size;
 
     // force expiration
     process.env.DATAFILES_FILE = 'test/multishas/multishas3.data.json';
@@ -136,8 +135,7 @@ describe('multishas', async () => {
 
     should.equal(app.get('bundles')[sha], undefined);
     should.equal(app.get('bundleCache')[sha], undefined);
-    // eslint-disable-next-line no-underscore-dangle
-    stackLen.should.equal(app._router.stack.length);
+    routersBefore.should.equal(app.get('shaRouters').size);
   });
 
   it('access via sha2', async () => {


### PR DESCRIPTION
…se 4a)

Eliminate the private Express API app._router.stack usage, which was needed to remove expired bundle middlewares and was a blocker for Express 5.

Replace with a Map<string, Router> stored in app state as 'shaRouters':
- registerApolloServer: stores Apollo middleware in the map instead of calling app.use() directly
- removeExpiredBundles: calls shaRouters.delete(sha) instead of splicing the router stack
- A single top-level dispatcher middleware routes /graphqlsha/:sha requests to the correct Apollo middleware by SHA lookup, passing req.url unchanged
- /cache and metrics now report shaRouters.size instead of _router.stack.length
- test/multishas: update expired bundle assertion to use shaRouters.size
- docs: update plan with implementation notes

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>