### PR TITLE
fix(server): join wildcard array segments with '/' in Express 5 diff …

### DIFF
--- a/docs/dependency-upgrade-plan.md
+++ b/docs/dependency-upgrade-plan.md
@@ -4,7 +4,7 @@
 
 The project has 17 outdated dependencies, ranging from trivial semver-minor bumps to fundamental rewrites (Apollo Server 2 is EOL, TypeScript is 6+ major versions behind). Several dependencies are coupled: Apollo Server 4 requires graphql 16, which requires modern TypeScript; Express 5 requires eliminating the private `_router.stack` hack. Chai 5+ is ESM-only and incompatible with this CommonJS project.
 
-The plan breaks upgrades into 7 phases across ~8 PRs, each independently mergeable.
+The plan breaks upgrades into 8 phases across ~10 PRs, each independently mergeable.
 
 ---
 
@@ -138,36 +138,42 @@ The largest and riskiest phase. Depends on Phase 1 (TS 5.x), Phase 2 (graphql 15
 
 ---
 
-## Phase 5: Express 4 to 5 (1 PR, ~3-5h)
+## Phase 5: Express 4 to 5 (1 PR + 1 hotfix, ~3-5h)
 
 Depends on Phase 4a (router refactor — no more `_router.stack`).
 
 **Package changes:**
-- `express`: `^4.17.1` -> `^5.2.0`
-- `@types/express`: `^4.17.21` -> `^5.0.0`
+- `express`: pinned to exact `"5.2.1"` (not `^5.2.1` — avoid surprises from patch releases)
+- `@types/express`: pinned to exact `"5.0.6"`
 
 **Code changes:**
-- `src/server.ts`: wildcard route syntax change:
+- `src/server.ts`: wildcard route syntax — path-to-regexp v8 (bundled with Express 5) uses `{/*rest}` for an **optional** wildcard (zero or more segments). `/*rest` (without braces) is non-optional and causes a 404 when no path follows the filetype:
   ```
   // Before: '/diff/:base_sha/:head_sha/:filetype/*?'
-  // After:  '/diff/:base_sha/:head_sha/:filetype/*rest'
+  // After:  '/diff/:base_sha/:head_sha/:filetype{/*rest}'
   ```
-- `src/server.ts`: `req.params[0]` -> `req.params.rest`
-- `src/server.ts`: `@types/express` v5 changes `ParamsDictionary` from `{ [key: string]: string }` to `{ [key: string]: string | string[] }`. TypeScript rejects `string | string[]` as an object index key. Fix by destructuring params with a type assertion at the top of each affected route handler:
+- `src/server.ts`: `req.params[0]` -> `req.params.rest`. **Critical:** in Express 5 (path-to-regexp v8), `req.params.rest` for a multi-segment path (e.g. `services/app-interface/app.yml`) is a **`string[]`**, not a `string`. Coercing it naively (template literal or `.toString()`) joins segments with commas, producing an invalid filepath. Must join explicitly:
+  ```typescript
+  const restParam = req.params.rest as string | string[] | undefined;
+  const restPath = Array.isArray(restParam) ? restParam.join('/') : (restParam ?? '');
+  ```
+- `src/server.ts`: `@types/express` v5 changes `ParamsDictionary` to `{ [key: string]: string | string[] }`. TypeScript rejects `string | string[]` as an index key. Fix by asserting params type at the top of affected route handlers:
   ```typescript
   const { base_sha: baseSha, head_sha: headSha } = req.params as Record<string, string>;
   ```
-  Affected routes: `/diff/:base_sha/:head_sha/:filetype/*rest`, `/diff/:base_sha/:head_sha`, `/git-commit/:sha`, `/git-commit-info/:sha`. Also rename `base_sha`/`head_sha` to camelCase in the handler body to satisfy the ESLint `camelcase` rule (use `// eslint-disable-next-line @typescript-eslint/naming-convention` on the destructuring line).
-- `src/server.ts`: In Express 5, `express.json()` does not set `req.body` for GET requests (leaves it `undefined`). Apollo v4's `expressMiddleware` checks `if (!req.body)` and returns 500. Add a middleware after `express.json()` that defaults `req.body` to `{}` when undefined, so GET GraphQL queries work:
+  Affected routes: `/diff/:base_sha/:head_sha/:filetype{/*rest}`, `/diff/:base_sha/:head_sha`, `/git-commit/:sha`, `/git-commit-info/:sha`. Use `// eslint-disable-next-line @typescript-eslint/naming-convention` on the destructuring line for the snake_case param names.
+- `src/server.ts`: In Express 5, `express.json()` does not set `req.body` for GET requests (leaves it `undefined`). Apollo v4's `expressMiddleware` rejects requests where `req.body` is undefined. Scope a defaulting middleware to GraphQL routes only:
   ```typescript
-  app.use((req, _res, next) => {
-    if (req.body === undefined) { (req as any).body = {}; }
+  app.use(['/graphql', '/graphqlsha'], (req, _res, next) => {
+    if (req.body === undefined) { Object.assign(req, { body: {} }); }
     next();
   });
   ```
 - Update README.md Limitations section (router stack issue resolved by Phase 4a)
 
-**Verify:** `npm test` + manual endpoint testing (including GET GraphQL query)
+**Post-merge hotfix:** The single-segment test path (`cluster.yml`) masked the `req.params.rest` array bug — `['cluster.yml'].toString()` happens to equal `'cluster.yml'`. Multi-segment paths used in production (e.g. `services/app-interface/app.yml`) hit `404` immediately after Phase 5 merged. Fixed in a follow-up PR with the explicit `Array.isArray` join and a regression test covering multi-segment paths.
+
+**Verify:** `npm test` + manual endpoint testing (including GET GraphQL query and multi-segment `/diff/` path)
 
 ---
 
@@ -202,17 +208,17 @@ Tooling-only, no runtime impact.
 
 ---
 
-## Suggested PR Order
+## PR Status
 
-| # | Phase | Description | Risk | Effort |
-|---|---|---|---|---|
-| 1 | 0 | Safe bumps (winston, dotenv, eslint-plugin-import) | LOW | ~1h |
-| 2 | 1 | TypeScript 3.8 -> 5.8 + @aws-sdk/client-s3 | MODERATE | ~2-4h |
-| 3 | 2 | graphql 14 -> 15, remove @types/graphql, update @types/express | LOW | ~1h |
-| 4 | 3 | prom-client 12 -> 15, express-prom-bundle 6 -> 8 | LOW-MOD | ~2-3h |
-| 5 | 4a | Router stack refactor (eliminate _router.stack) | MODERATE | ~4-6h |
-| 6 | 4b | Apollo Server 2 -> @apollo/server 4, graphql 15 -> 16 | HIGH | ~8-16h |
-| 7 | 5 | Express 4 -> 5 | MODERATE | ~3-5h |
-| 8 | 6 | ESLint 8 -> 9, @typescript-eslint v8, flat config | MODERATE | ~3-5h |
-
-**Total estimated effort: ~24-40h**
+| # | Phase | Description | Status |
+|---|---|---|---|
+| 1 | 0 | Safe bumps (winston, dotenv, eslint-plugin-import) | ✅ Merged (#277) |
+| 2 | 1 | TypeScript 3.8 -> 5.8 + @aws-sdk/client-s3 | ✅ Merged (#278) |
+| 3 | 2 | graphql 14 -> 15, remove @types/graphql, update @types/express | ✅ Merged (#280) |
+| 4 | 3 | prom-client 12 -> 15, express-prom-bundle 6 -> 8 | ✅ Merged (#281) |
+| 5 | 4a | Router stack refactor (eliminate _router.stack) | ✅ Merged (#282) |
+| 6 | 4b | Apollo Server 2 -> @apollo/server 4, graphql 15 -> 16 | ✅ Merged (#283) |
+| 7 | 5 | Express 4 -> 5 | ✅ Merged (#285) |
+| 8 | 5 hotfix | Fix multi-segment wildcard array join in /diff route | 🔄 Open (fix/express5-wildcard-array-join) |
+| 9 | 6 | ESLint 8 -> 9, @typescript-eslint v8, flat config, drop airbnb-base | 🔄 Open (#286) |
+| 10 | 7 | Prettier | 📋 Planned |

--- a/src/server.ts
+++ b/src/server.ts
@@ -272,10 +272,12 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
   app.get(
     '/diff/:base_sha/:head_sha/:filetype{/*rest}',
     (req: express.Request, res: express.Response) => {
+      const params = req.params as Record<string, string>;
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      const {
-        base_sha: baseSha, head_sha: headSha, filetype, rest,
-      } = req.params as Record<string, string>;
+      const { base_sha: baseSha, head_sha: headSha, filetype } = params;
+      // Express 5 (path-to-regexp v8) returns wildcard segments as an array
+      const restParam = req.params.rest as unknown as string[] | string | undefined;
+      const restPath = Array.isArray(restParam) ? restParam.join('/') : (restParam ?? '');
       const baseBundle: db.Bundle = req.app.get('bundles')[baseSha];
       if (baseBundle === undefined) {
         res.status(404).send(`Bundle ${baseSha} not found`);
@@ -287,7 +289,7 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
         return;
       }
 
-      const filepath = `/${rest ?? ''}`;
+      const filepath = `/${restPath}`;
       switch (filetype) {
         case 'datafile':
         {

--- a/src/server.ts
+++ b/src/server.ts
@@ -275,8 +275,8 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
       const params = req.params as Record<string, string>;
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const { base_sha: baseSha, head_sha: headSha, filetype } = params;
-      // Express 5 (path-to-regexp v8) returns wildcard segments as an array
-      const restParam = req.params.rest as unknown as string[] | string | undefined;
+      // Express 5 (path-to-regexp v8) returns wildcard segments as a string[]
+      const restParam = req.params.rest as string | string[] | undefined;
       const restPath = Array.isArray(restParam) ? restParam.join('/') : (restParam ?? '');
       const baseBundle: db.Bundle = req.app.get('bundles')[baseSha];
       if (baseBundle === undefined) {

--- a/test/diff/diff.test.ts
+++ b/test/diff/diff.test.ts
@@ -13,8 +13,8 @@ chai.use(chaiHttp);
 chai.should();
 
 const diskBundles = 'fs://test/diff/old.data.json,fs://test/diff/new.data.json';
-const oldSha = 'bf56095bf2ada36a6b2deca9cb9b6616d536b5c9ce230f0905296165d221a66b';
-const newSha = '302071115aa5dda8559f6e582fa7b6db7e0b64b5a9a6a9e3e9c22e2f86567f4b';
+const oldSha = 'c1571df5261ca8ad3344a93c474e325f8cd5628df14f20569d12b22f467b81fb';
+const newSha = '66d95c6b4a8c49317b9be0765190d0f487651d0e305e3062374124f79d955c2e';
 
 describe('diff', async () => {
   let srv: http.Server;
@@ -74,6 +74,15 @@ describe('diff', async () => {
     resp.body.datafileschema.should.equal('/openshift/cluster-1.yml');
     resp.body.old.automationToken.path.should.equals('secret-old');
     resp.body.new.automationToken.path.should.equals('secret-new');
+  });
+
+  it('serve single datafile diff with multi-segment path', async () => {
+    // Express 5 (path-to-regexp v8) returns wildcard segments as string[]; verify they are
+    // joined back with '/' so multi-segment paths resolve correctly (regression for /*rest)
+    const resp = await chai.request(srv)
+      .get(`/diff/${oldSha}/${newSha}/datafile/services/app-interface/app.yml`);
+    resp.should.have.status(200);
+    resp.body.datafilepath.should.equal('/services/app-interface/app.yml');
   });
 
   it('serve single datafile diff missing', async () => {

--- a/test/diff/new.data.json
+++ b/test/diff/new.data.json
@@ -9,6 +9,10 @@
       "automationToken": {
         "path": "secret-new"
       }
+    },
+    "/services/app-interface/app.yml": {
+      "$schema": "/app-interface/app-1.yml",
+      "name": "app-new"
     }
   },
   "graphql": [
@@ -89,10 +93,10 @@
       "sha256sum": "new_sha",
       "backrefs": [
         {
-            "path": "/cluster.yml",
-            "datafileSchema": "/openshift/cluster-1.yml",
-            "type": "Cluster_v1",
-            "jsonpath": "important.resource"
+          "path": "/cluster.yml",
+          "datafileSchema": "/openshift/cluster-1.yml",
+          "type": "Cluster_v1",
+          "jsonpath": "important.resource"
         }
       ]
     }

--- a/test/diff/old.data.json
+++ b/test/diff/old.data.json
@@ -9,6 +9,10 @@
       "automationToken": {
         "path": "secret-old"
       }
+    },
+    "/services/app-interface/app.yml": {
+      "$schema": "/app-interface/app-1.yml",
+      "name": "app-old"
     }
   },
   "graphql": [
@@ -89,10 +93,10 @@
       "sha256sum": "old_sha",
       "backrefs": [
         {
-            "path": "/cluster.yml",
-            "datafileSchema": "/openshift/cluster-1.yml",
-            "type": "Cluster_v1",
-            "jsonpath": "important.resource"
+          "path": "/cluster.yml",
+          "datafileSchema": "/openshift/cluster-1.yml",
+          "type": "Cluster_v1",
+          "jsonpath": "important.resource"
         }
       ]
     }


### PR DESCRIPTION
…route

In Express 5 (path-to-regexp v8), the {/*rest} optional wildcard captures multi-segment paths (e.g. services/app-interface/app.yml) as a string[] instead of a string. Coercing that array with template literals joins elements with commas, producing an invalid filepath and a 404.

Fix by explicitly checking Array.isArray(restParam) and joining with '/'.

Adds a regression test and test fixture entry for a multi-segment datafile path to prevent recurrence.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>



Error in promotion:
```
[2026-04-27 05:49:48] [INFO] [DRY-RUN] [change_owners.py:run:372] - running in `limited` mode that prevents full self-service MR 185296 contains changes other than datafiles, resources, docs or testdata
[2026-04-27 05:49:52] [INFO] [DRY-RUN] [change_owners.py:run:405] - fetching change types and permissions from comparison bundle (sha=0f71635fd9dfca7bfeba3cbdbd713bcf99a3a08d9a6666ebf1498560429fe9ff, commit_id=d1f4d4574b3733cd51b3fb1449a5257763cfeaa2, build_time 2026-04-27T05:45:56+00:00)
[2026-04-27 05:49:55] [INFO] [DRY-RUN] [change_owners.py:run:421] - detected 3 changed files with 4 differences and 0 metadata-only changes
[2026-04-27 05:50:06] [ERROR] [DRY-RUN] [change_owners.py:run:546] - Traceback (most recent call last):
  File "/work/reconcile/change_owners/change_owners.py", line 426, in run
    cover_changes(
  File "/work/reconcile/change_owners/change_owners.py", line 72, in cover_changes
    cover_changes_with_self_service_roles(
  File "/work/reconcile/change_owners/self_service_roles.py", line 87, in cover_changes_with_self_service_roles
    for bc, ctx in change_type_contexts_for_self_service_roles(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/change_owners/self_service_roles.py", line 145, in change_type_contexts_for_self_service_roles
    for ownership in ctp.find_context_file_refs(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/change_owners/change_types.py", line 588, in find_context_file_refs
    for ec in ce.expand(change, expansion_trail_copy)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/change_owners/change_types.py", line 401, in expand
    ref_old_data, ref_new_data = self.file_diff_resolver.lookup_file_diff(ref)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/change_owners/bundle.py", line 178, in lookup_file_diff
    data = get_diff(
           ^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/sretoolbox/utils/retry.py", line 84, in f_retry
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/utils/gql.py", line 478, in get_diff
    response.raise_for_status()
  File "/opt/app-root/lib64/python3.12/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://localhost:4000/diff/0f71635fd9dfca7bfeba3cbdbd713bcf99a3a08d9a6666ebf1498560429fe9ff/8818325010002a4c5d2199d9228ba2bc2dda20618e1928b6646de9332d2cf0b1/datafile/services/app-interface/app.yml
```
