### PR TITLE
chore(deps): replace deep-diff with microdiff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "@apollo/server": "5.5.1",
         "@as-integrations/express5": "1.1.2",
         "@aws-sdk/client-s3": "^3.1033.0",
-        "deep-diff": "1.0.2",
         "dotenv": "^16.6.1",
         "express": "5.2.1",
         "express-prom-bundle": "^8.0.0",
         "graphql": "^16.13.2",
         "jsonpointer": "^5.0.1",
+        "microdiff": "1.5.0",
         "prom-client": "^15.1.3",
         "winston": "^3.19.0"
       },
@@ -3478,13 +3478,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-diff": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
-      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -5726,6 +5719,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==",
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "@apollo/server": "5.5.1",
     "@as-integrations/express5": "1.1.2",
     "@aws-sdk/client-s3": "^3.1033.0",
-    "deep-diff": "1.0.2",
     "dotenv": "^16.6.1",
     "express": "5.2.1",
     "express-prom-bundle": "^8.0.0",
     "graphql": "^16.13.2",
     "jsonpointer": "^5.0.1",
+    "microdiff": "1.5.0",
     "prom-client": "^15.1.3",
     "winston": "^3.19.0"
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import * as metrics from './metrics';
 import { generateAppSchema } from './schema';
 import { logger } from './logger';
 
-const deepDiff = require('deep-diff');
+import microdiff from 'microdiff';
 
 // sha expiration time (in ms). Defaults to 20m.
 const BUNDLE_SHA_TTL = Number(process.env.BUNDLE_SHA_TTL) || 20 * 60 * 1000;
@@ -357,12 +357,12 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
         return;
       }
 
-      // deepDiff can only diff objects, Map is not supported
-      const dataDiffs = deepDiff(
+      const dataDiffs = microdiff(
         Object.fromEntries(baseBundle.datafiles),
         Object.fromEntries(headBundle.datafiles),
+        { cyclesFix: false },
       );
-      const resourceDiffs = deepDiff(
+      const resourceDiffs = microdiff(
         Object.fromEntries(
           Array.from(baseBundle.resourcefiles, ([path, resource]) => [
             path,
@@ -375,6 +375,7 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
             resource.sha256sum,
           ]),
         ),
+        { cyclesFix: false },
       );
 
       const changes: any = {
@@ -382,8 +383,8 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
         resources: {},
       };
 
-      (resourceDiffs || []).forEach((diff: any) => {
-        const path = diff.path[0];
+      resourceDiffs.forEach((diff) => {
+        const path = String(diff.path[0]);
         const oldRes = baseBundle.resourcefiles.get(path);
         const newRes = headBundle.resourcefiles.get(path);
         changes.resources[path] = {
@@ -393,8 +394,8 @@ export const appFromBundle = async (bundlePromises: Promise<db.Bundle>[]) => {
         };
       });
 
-      (dataDiffs || []).forEach((diff: any) => {
-        const path = diff.path[0];
+      dataDiffs.forEach((diff) => {
+        const path = String(diff.path[0]);
         const oldRes = baseBundle.datafiles.get(path);
         const newRes = headBundle.datafiles.get(path);
         changes.datafiles[path] = {


### PR DESCRIPTION
deep-diff@1.0.2 has been unmaintained since 2018 and is now officially deprecated. Replace it with microdiff, which is actively maintained, has built-in TypeScript types, and produces identical output for the /diff endpoint.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>