### PR TITLE
feat(template): add IMAGE_DIGEST parameter for digest-pinned image references

### DIFF
--- a/openshift/app-interface.autoscale.yaml
+++ b/openshift/app-interface.autoscale.yaml
@@ -168,7 +168,7 @@ objects:
             timeoutSeconds: 1
             initialDelaySeconds: 10
           resources: "${{S3RELOADER_RESOURCES}}"
-        - image: ${IMAGE}:${IMAGE_TAG}
+        - image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           imagePullPolicy: Always
           name: app-interface
           env:
@@ -280,6 +280,10 @@ parameters:
   value: latest
   displayName: App interface version
   description: App interface version which defaults to latest
+- name: IMAGE_DIGEST
+  value: ''
+  displayName: App interface image digest
+  description: App interface image digest.
 - name: IMAGE_PULL_SECRETS
   value: '[]'
   description: Secrets to use for pulling qontract-server images

--- a/openshift/app-interface.autoscale.yaml
+++ b/openshift/app-interface.autoscale.yaml
@@ -281,7 +281,7 @@ parameters:
   displayName: App interface version
   description: App interface version which defaults to latest
 - name: IMAGE_DIGEST
-  value: ''
+  required: true
   displayName: App interface image digest
   description: App interface image digest.
 - name: IMAGE_PULL_SECRETS


### PR DESCRIPTION
## Summary

- Adds `IMAGE_DIGEST` parameter to `openshift/app-interface.autoscale.yaml`
- Changes the qontract-server container image reference from \`${IMAGE}:${IMAGE_TAG}\` to \`${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}\` to support digest pinning
- Enables `openshift-saas-deploy` to resolve and pin Konflux-built images by digest alongside the tag

## Related

- app-interface MR: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/191718 (adds `REGISTRY_IMG` to saas file for digest resolution)
- qontract-reconcile PR: https://github.com/app-sre/qontract-reconcile/pull/5603 (bumps `sretoolbox` to 4.0.1 to fix `:tag@sha256:digest` image URL parsing)

## Test plan

- [ ] Dry-run passes for `saas-qontract-server-int` with `app-interface-production-int` environment
- [ ] Deployed image reference includes both tag and digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)