### PR TITLE
feat(template): rename IMAGE parameter to REGISTRY_IMG

### DIFF
--- a/openshift/app-interface.autoscale.yaml
+++ b/openshift/app-interface.autoscale.yaml
@@ -168,7 +168,7 @@ objects:
             timeoutSeconds: 1
             initialDelaySeconds: 10
           resources: "${{S3RELOADER_RESOURCES}}"
-        - image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
+        - image: ${REGISTRY_IMG}:${IMAGE_TAG}@${IMAGE_DIGEST}
           imagePullPolicy: Always
           name: app-interface
           env:
@@ -272,7 +272,7 @@ objects:
       metadata:
         value: ${TARGET_CPU_UTILIZATION_PERCENTAGE}
 parameters:
-- name: IMAGE
+- name: REGISTRY_IMG
   value: quay.io/app-sre/qontract-server
   displayName: App interface image
   description: App interface docker image. Defaults to quay.io/app-sre/app-interface

--- a/openshift/app-interface.yaml
+++ b/openshift/app-interface.yaml
@@ -167,7 +167,7 @@ objects:
             timeoutSeconds: 1
             initialDelaySeconds: 10
           resources: "${{S3RELOADER_RESOURCES}}"
-        - image: ${IMAGE}:${IMAGE_TAG}
+        - image: ${REGISTRY_IMG}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: app-interface
           env:
@@ -257,7 +257,7 @@ objects:
     selector:
       deployment: app-interface
 parameters:
-- name: IMAGE
+- name: REGISTRY_IMG
   value: quay.io/app-sre/qontract-server
   displayName: App interface image
   description: App interface docker image. Defaults to quay.io/app-sre/app-interface


### PR DESCRIPTION
Align with the parameter name used by qontract-reconcile saas-deploy integration, removing the need for a duplicate IMAGE parameter in app-interface saas files.

Assisted-by: Claude Sonnet 4.6