### PR TITLE
feat(template): add digest-pinned image references for sidecar contai…

### DIFF
--- a/openshift/app-interface.autoscale.yaml
+++ b/openshift/app-interface.autoscale.yaml
@@ -74,7 +74,7 @@ objects:
           emptyDir:
             medium: Memory
         containers:
-        - image: ${IMAGE_GATE}:${IMAGE_GATE_TAG}
+        - image: ${IMAGE_GATE}:${IMAGE_GATE_TAG}@${IMAGE_GATE_DIGEST}
           imagePullPolicy: Always
           name: app-interface-nginx-gate
           env:
@@ -122,7 +122,7 @@ objects:
             initialDelaySeconds: 10
           resources: "${{GATE_RESOURCES}}"
 
-        - image: ${IMAGE_RELOADER}:${IMAGE_RELOADER_TAG}
+        - image: ${IMAGE_RELOADER}:${IMAGE_RELOADER_TAG}@${IMAGE_RELOADER_DIGEST}
           imagePullPolicy: Always
           name: s3-reloader
           env:
@@ -299,6 +299,9 @@ parameters:
   value: latest
   displayName: App interface nginx gate version
   description: App interface nginx gate version which defaults to latest
+- name: IMAGE_GATE_DIGEST
+  displayName: App interface nginx gate image digest
+  description: App interface nginx gate image digest.
 - name: IMAGE_GATE_AUTH_DISABLE
   value: "false"
   description: Set to true to disable authentication for accessing qontract server
@@ -310,6 +313,9 @@ parameters:
   value: quay.io/app-sre/s3-reload
 - name: IMAGE_RELOADER_TAG
   value: 0bc8c97
+- name: IMAGE_RELOADER_DIGEST
+  displayName: s3-reloader image digest
+  description: s3-reloader image digest.
 - name: MAX_OLD_SPACE_SIZE
   value: "400"
 

--- a/openshift/app-interface.autoscale.yaml
+++ b/openshift/app-interface.autoscale.yaml
@@ -294,12 +294,13 @@ parameters:
 - name: TARGET_CPU_UTILIZATION_PERCENTAGE
   value: "80"
 - name: IMAGE_GATE
-  value: quay.io/app-sre/nginx-gate
+  value: quay.io/redhat-services-prod/app-sre-tenant/nginx-gate-master/nginx-gate-master
 - name: IMAGE_GATE_TAG
-  value: latest
+  value: cdeb409
   displayName: App interface nginx gate version
   description: App interface nginx gate version which defaults to latest
 - name: IMAGE_GATE_DIGEST
+  value: sha256:11ff1a9d8934011c4027ee78ac24238a407716210678579a33de5a4a26382c2b
   displayName: App interface nginx gate image digest
   description: App interface nginx gate image digest.
 - name: IMAGE_GATE_AUTH_DISABLE
@@ -310,10 +311,11 @@ parameters:
   description: Maximum nginx cache size
 
 - name: IMAGE_RELOADER
-  value: quay.io/app-sre/s3-reload
+  value: quay.io/redhat-services-prod/app-sre-tenant/s3-reload-master/s3-reload-master
 - name: IMAGE_RELOADER_TAG
-  value: 0bc8c97
+  value: 50f2723
 - name: IMAGE_RELOADER_DIGEST
+  value: sha256:ca31c597fb3c179d35eacee423551cec6e7fbb53bbe1b764b6879cea1bb7edb6
   displayName: s3-reloader image digest
   description: s3-reloader image digest.
 - name: MAX_OLD_SPACE_SIZE


### PR DESCRIPTION
…ners

Add IMAGE_GATE_DIGEST and IMAGE_RELOADER_DIGEST parameters to the autoscale template so nginx-gate and s3-reloader sidecars are pinned by digest, consistent with the main app-interface container.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>